### PR TITLE
add Schema.org JSON-LD and improve dataset page layout

### DIFF
--- a/scripts/generate_dataset_pages.js
+++ b/scripts/generate_dataset_pages.js
@@ -53,63 +53,96 @@ function formatZenodoDOI(doi) {
   return `https://doi.org/${doi}`;
 }
 
+// Escape double quotes for YAML frontmatter string values
+function escapeFM(val) {
+  if (val === null || val === undefined) return '';
+  return String(val).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
 // Read and process all dataset folders
 const generateDatasetPages = () => {
   // Get all subdirectories in the datasets directory
   const datasetFolders = fs.readdirSync(datasetsDir, { withFileTypes: true })
     .filter(dirent => dirent.isDirectory())
     .map(dirent => dirent.name);
-  
+
   datasetFolders.forEach(folder => {
     // Look for metadata file in the dataset folder
     const metadataPath = path.join(datasetsDir, folder, `${folder}_metadata.json`);
-    
+
     if (fs.existsSync(metadataPath)) {
       const data = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
-      
+
       // Format the reference
       const apaReference = data.reference_a ? formatAPAReference(data.reference_a) : '';
       const additionalReference = data.reference_b ? formatAPAReference(data.reference_b) : '';
-      
+
+      const zenodoUrl = data.zenodo_doi ? formatZenodoDOI(data.zenodo_doi) : '';
+
       // Create markdown content for the dataset page
       const content = `---
-title: "${data.first_author} (${data.year})"
+title: "${escapeFM(data.first_author)} (${data.year})"
 date: ${new Date().toISOString().split('T')[0]}
 draft: false
+dataset_id: "${escapeFM(folder)}"
+first_author: "${escapeFM(data.first_author)}"
+year: ${data.year}
+paper_doi: "${escapeFM(data.paper_doi || '')}"
+zenodo_doi: "${escapeFM(data.zenodo_doi || '')}"
+license: "${escapeFM(data.license || '')}"
+n_participants: ${data.n_participants || 0}
+n_time_points: ${data.n_time_points || 0}
+n_days: "${escapeFM(String(data.n_days || ''))}"
+topics: "${escapeFM(data.topics || '')}"
+sampling_scheme: "${escapeFM(data.sampling_scheme || '')}"
+participants: "${escapeFM(data.participants || '')}"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+${data.zenodo_doi ? `<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="${zenodoUrl}">${data.zenodo_doi}</a></p>` : '<p class="dataset-access-doi"><em>Zenodo DOI not yet available</em></p>'}
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("${folder}")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("${folder}")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** ${data.first_author}
-- **Year:** ${data.year}
-- **Paper DOI:** [${data.paper_doi}](${data.paper_doi})
-- **Topics:** ${data.topics || ''}
-
-## Data Characteristics
-
-- **Participants:** ${data.n_participants} (${data.participants || ''})
-- **Time Points:** ${data.n_time_points}
-- **Days:** ${data.n_days}
-- **Beeps per Day:** ${formatBeepsPerDay(data.n_beeps_per_day)}
-- **Sampling Scheme:** ${data.sampling_scheme || ''}
-- **Raw Timestamp:** ${data.raw_time_stamp || ''}
-- **Implicit Missingness:** ${data.implicit_missingness || ''}
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> ${data.first_author}</li>
+<li><strong>Year:</strong> ${data.year}</li>
+${data.paper_doi ? `<li><strong>Paper DOI:</strong> <a href="${data.paper_doi}">${data.paper_doi}</a></li>` : ''}
+<li><strong>Topics:</strong> ${data.topics || ''}</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> ${data.n_participants}${data.participants ? ` (${data.participants})` : ''}</li>
+<li><strong>Time Points:</strong> ${data.n_time_points}</li>
+<li><strong>Days:</strong> ${data.n_days}</li>
+<li><strong>Beeps per Day:</strong> ${formatBeepsPerDay(data.n_beeps_per_day)}</li>
+<li><strong>Sampling Scheme:</strong> ${data.sampling_scheme || ''}</li>
+<li><strong>Raw Timestamp:</strong> ${data.raw_time_stamp || ''}</li>
+<li><strong>Implicit Missingness:</strong> ${data.implicit_missingness || ''}</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** ${data.cross_sectional_available || 'not specified'}
 - **Passive Sensor Data:** ${data.passive_data_available || 'not specified'}
-- **Link to Original Data:** [${data.link_to_data}](${data.link_to_data})
-- **Link to Codebook:** ${data.link_to_codebook ? `[${data.link_to_codebook}](${data.link_to_codebook})` : 'not available'}
-- **Link to Code:** [${data.link_to_code}](${data.link_to_code})
 - **License:** ${data.license || 'not specified'}
 
-## Data Access
-
-- **Zenodo DOI:** ${data.zenodo_doi ? `[${data.zenodo_doi}](${formatZenodoDOI(data.zenodo_doi)})` : 'not available'}
-- **R:** \`openesm::get_dataset("${folder}")\`
-- **Python:** \`openesm.get_dataset("${folder}")\`
+<div class="dataset-links">
+${data.zenodo_doi ? `<p><strong>Harmonized Data (Zenodo):</strong> <a href="${zenodoUrl}">${data.zenodo_doi}</a></p>` : ''}
+<p><strong>Original Source Data:</strong> <a href="${data.link_to_data}">${data.link_to_data}</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+${data.link_to_codebook ? `<p><strong>Codebook:</strong> <a href="${data.link_to_codebook}">${data.link_to_codebook}</a></p>` : ''}
+${data.link_to_code ? `<p><strong>Code:</strong> <a href="${data.link_to_code}">${data.link_to_code}</a></p>` : ''}
+</div>
 
 ${data.additional_comments ? `## Additional Comments\n\n${data.additional_comments}\n` : ''}
 
@@ -129,7 +162,7 @@ No changes yet.
 |------|-------------|------|------------------|---------|--------|----------------|--------|----------------|----------|----------|
 ${data.features.map(feature => `| ${feature.name} | ${formatForTable(feature.description)} | ${feature.variable_type} | ${formatForTable(feature.answer_categories)} | ${formatForTable(feature.details)} | ${formatForTable(feature.labels)} | ${formatForTable(feature.transformation)} | ${formatForTable(feature.source)} | ${formatForTable(feature.assessment_type)} | ${formatForTable(feature.construct)} | ${formatForTable(feature.comments)} |`).join('\n')}
 `;
-      
+
       // Write the markdown file
       const outputPath = path.join(outputDir, `${folder}.md`);
       fs.writeFileSync(outputPath, content);
@@ -142,4 +175,3 @@ ${data.features.map(feature => `| ${feature.name} | ${formatForTable(feature.des
 
 
 generateDatasetPages();
-

--- a/scripts/generate_dataset_pages.js
+++ b/scripts/generate_dataset_pages.js
@@ -56,7 +56,16 @@ function formatZenodoDOI(doi) {
 // Escape double quotes for YAML frontmatter string values
 function escapeFM(val) {
   if (val === null || val === undefined) return '';
-  return String(val).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return String(val)
+    .replace(/\r\n|\r|\n/g, ' ')
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"');
+}
+
+// Return true only for valid http/https URLs (not placeholders like "-")
+function isValidUrl(val) {
+  if (!val || typeof val !== 'string') return false;
+  return /^https?:\/\//i.test(val.trim());
 }
 
 // Read and process all dataset folders
@@ -139,9 +148,9 @@ ${data.paper_doi ? `<li><strong>Paper DOI:</strong> <a href="${data.paper_doi}">
 
 <div class="dataset-links">
 ${data.zenodo_doi ? `<p><strong>Harmonized Data (Zenodo):</strong> <a href="${zenodoUrl}">${data.zenodo_doi}</a></p>` : ''}
-<p><strong>Original Source Data:</strong> <a href="${data.link_to_data}">${data.link_to_data}</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
-${data.link_to_codebook ? `<p><strong>Codebook:</strong> <a href="${data.link_to_codebook}">${data.link_to_codebook}</a></p>` : ''}
-${data.link_to_code ? `<p><strong>Code:</strong> <a href="${data.link_to_code}">${data.link_to_code}</a></p>` : ''}
+${isValidUrl(data.link_to_data) ? `<p><strong>Original Source Data:</strong> <a href="${data.link_to_data}">${data.link_to_data}</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>` : ''}
+${isValidUrl(data.link_to_codebook) ? `<p><strong>Codebook:</strong> <a href="${data.link_to_codebook}">${data.link_to_codebook}</a></p>` : ''}
+${isValidUrl(data.link_to_code) ? `<p><strong>Code:</strong> <a href="${data.link_to_code}">${data.link_to_code}</a></p>` : ''}
 </div>
 
 ${data.additional_comments ? `## Additional Comments\n\n${data.additional_comments}\n` : ''}

--- a/website/assets/css/extended/custom.css
+++ b/website/assets/css/extended/custom.css
@@ -441,3 +441,114 @@ body .main {
     display: none !important;
   }
 }
+
+/* ── Dataset page layout ───────────────────────────────────────────────── */
+
+/* Access box — prominent callout at the top of each dataset page */
+.dataset-access-box {
+  border: 1px solid var(--primary-blue);
+  border-left: 4px solid var(--primary-blue);
+  border-radius: 6px;
+  background-color: rgba(8, 90, 179, 0.04);
+  padding: 1.25rem 1.5rem;
+  margin: 0 0 1.75rem 0;
+}
+
+.dataset-access-title {
+  margin-top: 0 !important;
+  margin-bottom: 0.6rem !important;
+  font-size: 1.25rem;
+  color: var(--primary-blue);
+}
+
+.dataset-access-doi {
+  margin: 0 0 0.75rem 0;
+}
+
+.dataset-code-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem 1.5rem;
+}
+
+.dataset-code-item {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.dataset-code-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--primary-blue);
+  flex-shrink: 0;
+  min-width: 3.5rem;
+}
+
+/* Two-column metadata grid (Study Info | Data Characteristics) */
+.dataset-meta-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-bottom: 1.75rem;
+}
+
+.dataset-meta-card {
+  border: 1px solid var(--border-gray);
+  border-radius: 6px;
+  padding: 1rem 1.25rem;
+  background: white;
+}
+
+.dataset-meta-card h2 {
+  margin-top: 0 !important;
+  margin-bottom: 0.75rem !important;
+  font-size: 1.1rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--border-gray);
+}
+
+.dataset-meta-card ul {
+  margin: 0;
+  padding-left: 0;
+  list-style: none;
+}
+
+.dataset-meta-card li {
+  margin-bottom: 0.35rem;
+  font-size: 0.9rem;
+}
+
+/* Links section within Data Availability */
+.dataset-links {
+  margin-top: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: var(--light-gray);
+  border-radius: 4px;
+  border: 1px solid var(--border-gray);
+}
+
+.dataset-links p {
+  margin: 0.3rem 0;
+  font-size: 0.9rem;
+}
+
+.dataset-link-note {
+  font-size: 0.8rem;
+  color: #666;
+  font-style: italic;
+}
+
+/* Responsive: stack grid on narrow screens */
+@media (max-width: 700px) {
+  .dataset-meta-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .dataset-code-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/website/content/datasets/0001_fried.md
+++ b/website/content/datasets/0001_fried.md
@@ -1,41 +1,66 @@
 ---
 title: "Fried (2021)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0001_fried"
+first_author: "Fried"
+year: 2021
+paper_doi: "https://doi.org/10.1177/21677026211017839"
+zenodo_doi: "10.5281/zenodo.17347269"
+license: "CC-BY 4.0"
+n_participants: 80
+n_time_points: 56
+n_days: "14"
+topics: "mental health, social contact, COVID"
+sampling_scheme: "4x/day fixed schedule"
+participants: "student sample"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347269">10.5281/zenodo.17347269</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0001_fried")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0001_fried")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Fried
-- **Year:** 2021
-- **Paper DOI:** [https://doi.org/10.1177/21677026211017839](https://doi.org/10.1177/21677026211017839)
-- **Topics:** mental health, social contact, COVID
-
-## Data Characteristics
-
-- **Participants:** 80 (student sample)
-- **Time Points:** 56
-- **Days:** 14
-- **Beeps per Day:** 4
-- **Sampling Scheme:** 4x/day fixed schedule
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** no
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Fried</li>
+<li><strong>Year:</strong> 2021</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1177/21677026211017839">https://doi.org/10.1177/21677026211017839</a></li>
+<li><strong>Topics:</strong> mental health, social contact, COVID</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 80 (student sample)</li>
+<li><strong>Time Points:</strong> 56</li>
+<li><strong>Days:</strong> 14</li>
+<li><strong>Beeps per Day:</strong> 4</li>
+<li><strong>Sampling Scheme:</strong> 4x/day fixed schedule</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> no</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/mvdpe/](https://osf.io/mvdpe/)
-- **Link to Codebook:** [https://osf.io/mx87b](https://osf.io/mx87b)
-- **Link to Code:** [https://osf.io/mvdpe/](https://osf.io/mvdpe/)
 - **License:** CC-BY 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347269](https://doi.org/10.5281/zenodo.17347269)
-- **R:** `openesm::get_dataset("0001_fried")`
-- **Python:** `openesm.get_dataset("0001_fried")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347269">10.5281/zenodo.17347269</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/mvdpe/">https://osf.io/mvdpe/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/mx87b">https://osf.io/mx87b</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/mvdpe/">https://osf.io/mvdpe/</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0002_nestler.md
+++ b/website/content/datasets/0002_nestler.md
@@ -1,41 +1,66 @@
 ---
 title: "Nestler (2022)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0002_nestler"
+first_author: "Nestler"
+year: 2022
+paper_doi: "https://doi.org/10.1007/s11336-021-09787-w"
+zenodo_doi: "10.5281/zenodo.17347328"
+license: "CC BY-NC 4.0"
+n_participants: 85
+n_time_points: 82
+n_days: "82"
+topics: "personality, affect, motivation"
+sampling_scheme: "1x/day unclear schedule"
+participants: "unclear"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347328">10.5281/zenodo.17347328</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0002_nestler")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0002_nestler")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Nestler
-- **Year:** 2022
-- **Paper DOI:** [https://doi.org/10.1007/s11336-021-09787-w](https://doi.org/10.1007/s11336-021-09787-w)
-- **Topics:** personality, affect, motivation
-
-## Data Characteristics
-
-- **Participants:** 85 (unclear)
-- **Time Points:** 82
-- **Days:** 82
-- **Beeps per Day:** 1
-- **Sampling Scheme:** 1x/day unclear schedule
-- **Raw Timestamp:** no
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Nestler</li>
+<li><strong>Year:</strong> 2022</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1007/s11336-021-09787-w">https://doi.org/10.1007/s11336-021-09787-w</a></li>
+<li><strong>Topics:</strong> personality, affect, motivation</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 85 (unclear)</li>
+<li><strong>Time Points:</strong> 82</li>
+<li><strong>Days:</strong> 82</li>
+<li><strong>Beeps per Day:</strong> 1</li>
+<li><strong>Sampling Scheme:</strong> 1x/day unclear schedule</li>
+<li><strong>Raw Timestamp:</strong> no</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/gmz7e](https://osf.io/gmz7e)
-- **Link to Codebook:** [https://osf.io/wjysp/?view_only=cb2bf9adeef14eb488d228ffe2141699](https://osf.io/wjysp/?view_only=cb2bf9adeef14eb488d228ffe2141699)
-- **Link to Code:** [https://osf.io/53scf/](https://osf.io/53scf/)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347328](https://doi.org/10.5281/zenodo.17347328)
-- **R:** `openesm::get_dataset("0002_nestler")`
-- **Python:** `openesm.get_dataset("0002_nestler")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347328">10.5281/zenodo.17347328</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/gmz7e">https://osf.io/gmz7e</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/wjysp/?view_only=cb2bf9adeef14eb488d228ffe2141699">https://osf.io/wjysp/?view_only=cb2bf9adeef14eb488d228ffe2141699</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/53scf/">https://osf.io/53scf/</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0003_hawks.md
+++ b/website/content/datasets/0003_hawks.md
@@ -1,41 +1,66 @@
 ---
 title: "Hawks (2023)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0003_hawks"
+first_author: "Hawks"
+year: 2023
+paper_doi: "https://doi.org/10.1016/j.bpsc.2022.12.002"
+zenodo_doi: "10.5281/zenodo.17347389"
+license: "CC BY-NC 4.0"
+n_participants: 122
+n_time_points: 30
+n_days: "10"
+topics: "momentary cognition, context, stress"
+sampling_scheme: "3x/day fixed time windows"
+participants: "adults"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347389">10.5281/zenodo.17347389</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0003_hawks")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0003_hawks")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Hawks
-- **Year:** 2023
-- **Paper DOI:** [https://doi.org/10.1016/j.bpsc.2022.12.002](https://doi.org/10.1016/j.bpsc.2022.12.002)
-- **Topics:** momentary cognition, context, stress
-
-## Data Characteristics
-
-- **Participants:** 122 (adults)
-- **Time Points:** 30
-- **Days:** 10
-- **Beeps per Day:** 3
-- **Sampling Scheme:** 3x/day fixed time windows
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Hawks</li>
+<li><strong>Year:</strong> 2023</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1016/j.bpsc.2022.12.002">https://doi.org/10.1016/j.bpsc.2022.12.002</a></li>
+<li><strong>Topics:</strong> momentary cognition, context, stress</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 122 (adults)</li>
+<li><strong>Time Points:</strong> 30</li>
+<li><strong>Days:</strong> 10</li>
+<li><strong>Beeps per Day:</strong> 3</li>
+<li><strong>Sampling Scheme:</strong> 3x/day fixed time windows</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** unclear
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://github.com/zwihawks/PredictingMomentaryCog](https://github.com/zwihawks/PredictingMomentaryCog)
-- **Link to Codebook:** [https://pmc.ncbi.nlm.nih.gov/articles/instance/10264553/bin/NIHMS1858073-supplement-1.pdf](https://pmc.ncbi.nlm.nih.gov/articles/instance/10264553/bin/NIHMS1858073-supplement-1.pdf)
-- **Link to Code:** [https://github.com/zwihawks/PredictingMomentaryCog](https://github.com/zwihawks/PredictingMomentaryCog)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347389](https://doi.org/10.5281/zenodo.17347389)
-- **R:** `openesm::get_dataset("0003_hawks")`
-- **Python:** `openesm.get_dataset("0003_hawks")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347389">10.5281/zenodo.17347389</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://github.com/zwihawks/PredictingMomentaryCog">https://github.com/zwihawks/PredictingMomentaryCog</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://pmc.ncbi.nlm.nih.gov/articles/instance/10264553/bin/NIHMS1858073-supplement-1.pdf">https://pmc.ncbi.nlm.nih.gov/articles/instance/10264553/bin/NIHMS1858073-supplement-1.pdf</a></p>
+<p><strong>Code:</strong> <a href="https://github.com/zwihawks/PredictingMomentaryCog">https://github.com/zwihawks/PredictingMomentaryCog</a></p>
+</div>
 
 
 

--- a/website/content/datasets/0004_wang.md
+++ b/website/content/datasets/0004_wang.md
@@ -1,41 +1,66 @@
 ---
 title: "Wang (2014)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0004_wang"
+first_author: "Wang"
+year: 2014
+paper_doi: "https://doi.org/10.1371/journal.pone.0266516"
+zenodo_doi: "10.5281/zenodo.17347425"
+license: "CC BY-NC 4.0"
+n_participants: 49
+n_time_points: 64
+n_days: "64"
+topics: "students, mental health, academic performance, stress, activity"
+sampling_scheme: "irregular"
+participants: "undergraduate students"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347425">10.5281/zenodo.17347425</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0004_wang")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0004_wang")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Wang
-- **Year:** 2014
-- **Paper DOI:** [https://doi.org/10.1371/journal.pone.0266516](https://doi.org/10.1371/journal.pone.0266516)
-- **Topics:** students, mental health, academic performance, stress, activity
-
-## Data Characteristics
-
-- **Participants:** 49 (undergraduate students)
-- **Time Points:** 64
-- **Days:** 64
-- **Beeps per Day:** 1
-- **Sampling Scheme:** irregular
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Wang</li>
+<li><strong>Year:</strong> 2014</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1371/journal.pone.0266516">https://doi.org/10.1371/journal.pone.0266516</a></li>
+<li><strong>Topics:</strong> students, mental health, academic performance, stress, activity</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 49 (undergraduate students)</li>
+<li><strong>Time Points:</strong> 64</li>
+<li><strong>Days:</strong> 64</li>
+<li><strong>Beeps per Day:</strong> 1</li>
+<li><strong>Sampling Scheme:</strong> irregular</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** yes
-- **Link to Original Data:** [https://pbh.tech.cornell.edu/data.html](https://pbh.tech.cornell.edu/data.html)
-- **Link to Codebook:** [https://studentlife.cs.dartmouth.edu/dataset.html](https://studentlife.cs.dartmouth.edu/dataset.html)
-- **Link to Code:** [https://github.com/CornellPACLab/data_heterogeneity](https://github.com/CornellPACLab/data_heterogeneity)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347425](https://doi.org/10.5281/zenodo.17347425)
-- **R:** `openesm::get_dataset("0004_wang")`
-- **Python:** `openesm.get_dataset("0004_wang")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347425">10.5281/zenodo.17347425</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://pbh.tech.cornell.edu/data.html">https://pbh.tech.cornell.edu/data.html</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://studentlife.cs.dartmouth.edu/dataset.html">https://studentlife.cs.dartmouth.edu/dataset.html</a></p>
+<p><strong>Code:</strong> <a href="https://github.com/CornellPACLab/data_heterogeneity">https://github.com/CornellPACLab/data_heterogeneity</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0005_wang.md
+++ b/website/content/datasets/0005_wang.md
@@ -1,41 +1,66 @@
 ---
 title: "Wang (2016)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0005_wang"
+first_author: "Wang"
+year: 2016
+paper_doi: "https://doi.org/10.1371/journal.pone.0266516"
+zenodo_doi: "10.5281/zenodo.17347402"
+license: "CC BY-NC 4.0"
+n_participants: 62
+n_time_points: 165
+n_days: "165"
+topics: "schizophrenia, passive sensing, mood"
+sampling_scheme: "1x/day on Monday, Wednesday, Friday"
+participants: "adults with diagnosis of schizophrenia, schizoaffective disorder, or psychosis"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347402">10.5281/zenodo.17347402</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0005_wang")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0005_wang")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Wang
-- **Year:** 2016
-- **Paper DOI:** [https://doi.org/10.1371/journal.pone.0266516](https://doi.org/10.1371/journal.pone.0266516)
-- **Topics:** schizophrenia, passive sensing, mood
-
-## Data Characteristics
-
-- **Participants:** 62 (adults with diagnosis of schizophrenia, schizoaffective disorder, or psychosis)
-- **Time Points:** 165
-- **Days:** 165
-- **Beeps per Day:** 1
-- **Sampling Scheme:** 1x/day on Monday, Wednesday, Friday
-- **Raw Timestamp:** unclear
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Wang</li>
+<li><strong>Year:</strong> 2016</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1371/journal.pone.0266516">https://doi.org/10.1371/journal.pone.0266516</a></li>
+<li><strong>Topics:</strong> schizophrenia, passive sensing, mood</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 62 (adults with diagnosis of schizophrenia, schizoaffective disorder, or psychosis)</li>
+<li><strong>Time Points:</strong> 165</li>
+<li><strong>Days:</strong> 165</li>
+<li><strong>Beeps per Day:</strong> 1</li>
+<li><strong>Sampling Scheme:</strong> 1x/day on Monday, Wednesday, Friday</li>
+<li><strong>Raw Timestamp:</strong> unclear</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** no
 - **Passive Sensor Data:** yes
-- **Link to Original Data:** [https://pbh.tech.cornell.edu/data.html](https://pbh.tech.cornell.edu/data.html)
-- **Link to Codebook:** [https://pbh.tech.cornell.edu/data.html](https://pbh.tech.cornell.edu/data.html)
-- **Link to Code:** [https://github.com/CornellPACLab/data_heterogeneity](https://github.com/CornellPACLab/data_heterogeneity)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347402](https://doi.org/10.5281/zenodo.17347402)
-- **R:** `openesm::get_dataset("0005_wang")`
-- **Python:** `openesm.get_dataset("0005_wang")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347402">10.5281/zenodo.17347402</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://pbh.tech.cornell.edu/data.html">https://pbh.tech.cornell.edu/data.html</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://pbh.tech.cornell.edu/data.html">https://pbh.tech.cornell.edu/data.html</a></p>
+<p><strong>Code:</strong> <a href="https://github.com/CornellPACLab/data_heterogeneity">https://github.com/CornellPACLab/data_heterogeneity</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0006_rowland.md
+++ b/website/content/datasets/0006_rowland.md
@@ -1,41 +1,66 @@
 ---
 title: "Rowland (2020)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0006_rowland"
+first_author: "Rowland"
+year: 2020
+paper_doi: "https://doi.org/10.1007/s12671-020-01335-4"
+zenodo_doi: "10.5281/zenodo.17347351"
+license: "CC BY-NC 4.0"
+n_participants: 125
+n_time_points: 240
+n_days: "40"
+topics: "mindfulness, affect, network"
+sampling_scheme: "6x/day random timing"
+participants: "undergraduate students"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347351">10.5281/zenodo.17347351</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0006_rowland")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0006_rowland")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Rowland
-- **Year:** 2020
-- **Paper DOI:** [https://doi.org/10.1007/s12671-020-01335-4](https://doi.org/10.1007/s12671-020-01335-4)
-- **Topics:** mindfulness, affect, network
-
-## Data Characteristics
-
-- **Participants:** 125 (undergraduate students)
-- **Time Points:** 240
-- **Days:** 40
-- **Beeps per Day:** 6
-- **Sampling Scheme:** 6x/day random timing
-- **Raw Timestamp:** no
-- **Implicit Missingness:** no
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Rowland</li>
+<li><strong>Year:</strong> 2020</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1007/s12671-020-01335-4">https://doi.org/10.1007/s12671-020-01335-4</a></li>
+<li><strong>Topics:</strong> mindfulness, affect, network</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 125 (undergraduate students)</li>
+<li><strong>Time Points:</strong> 240</li>
+<li><strong>Days:</strong> 40</li>
+<li><strong>Beeps per Day:</strong> 6</li>
+<li><strong>Sampling Scheme:</strong> 6x/day random timing</li>
+<li><strong>Raw Timestamp:</strong> no</li>
+<li><strong>Implicit Missingness:</strong> no</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/jmz2n/](https://osf.io/jmz2n/)
-- **Link to Codebook:** [https://osf.io/5t4yg](https://osf.io/5t4yg)
-- **Link to Code:** [https://osf.io/jmz2n/](https://osf.io/jmz2n/)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347351](https://doi.org/10.5281/zenodo.17347351)
-- **R:** `openesm::get_dataset("0006_rowland")`
-- **Python:** `openesm.get_dataset("0006_rowland")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347351">10.5281/zenodo.17347351</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/jmz2n/">https://osf.io/jmz2n/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/5t4yg">https://osf.io/5t4yg</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/jmz2n/">https://osf.io/jmz2n/</a></p>
+</div>
 
 
 

--- a/website/content/datasets/0008_westhoff.md
+++ b/website/content/datasets/0008_westhoff.md
@@ -1,41 +1,66 @@
 ---
 title: "Westhoff (2024)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0008_westhoff"
+first_author: "Westhoff"
+year: 2024
+paper_doi: "https://doi.org/10.1038/s41598-024-58598-3"
+zenodo_doi: "10.5281/zenodo.17347510"
+license: "CC-BY 4.0"
+n_participants: 114
+n_time_points: 105
+n_days: "21"
+topics: "psychological flexibility, cognition, affect"
+sampling_scheme: "5x/day semi-random schedule"
+participants: "young adults"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347510">10.5281/zenodo.17347510</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0008_westhoff")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0008_westhoff")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Westhoff
-- **Year:** 2024
-- **Paper DOI:** [https://doi.org/10.1038/s41598-024-58598-3](https://doi.org/10.1038/s41598-024-58598-3)
-- **Topics:** psychological flexibility, cognition, affect
-
-## Data Characteristics
-
-- **Participants:** 114 (young adults)
-- **Time Points:** 105
-- **Days:** 21
-- **Beeps per Day:** 5
-- **Sampling Scheme:** 5x/day semi-random schedule
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** no
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Westhoff</li>
+<li><strong>Year:</strong> 2024</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1038/s41598-024-58598-3">https://doi.org/10.1038/s41598-024-58598-3</a></li>
+<li><strong>Topics:</strong> psychological flexibility, cognition, affect</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 114 (young adults)</li>
+<li><strong>Time Points:</strong> 105</li>
+<li><strong>Days:</strong> 21</li>
+<li><strong>Beeps per Day:</strong> 5</li>
+<li><strong>Sampling Scheme:</strong> 5x/day semi-random schedule</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> no</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** yes
-- **Link to Original Data:** [https://doi.org/10.1038/s41598-024-58598-3](https://doi.org/10.1038/s41598-024-58598-3)
-- **Link to Codebook:** [-](-)
-- **Link to Code:** [https://osf.io/ejtzs/](https://osf.io/ejtzs/)
 - **License:** CC-BY 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347510](https://doi.org/10.5281/zenodo.17347510)
-- **R:** `openesm::get_dataset("0008_westhoff")`
-- **Python:** `openesm.get_dataset("0008_westhoff")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347510">10.5281/zenodo.17347510</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://doi.org/10.1038/s41598-024-58598-3">https://doi.org/10.1038/s41598-024-58598-3</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="-">-</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/ejtzs/">https://osf.io/ejtzs/</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0010_geschwind.md
+++ b/website/content/datasets/0010_geschwind.md
@@ -1,41 +1,66 @@
 ---
 title: "Geschwind (2013)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0010_geschwind"
+first_author: "Geschwind"
+year: 2013
+paper_doi: "https://doi.org/10.1371/journal.pone.0060188"
+zenodo_doi: "10.5281/zenodo.17347473"
+license: "CC BY-NC 4.0"
+n_participants: 129
+n_time_points: 200
+n_days: "20"
+topics: "depression, neuroticism, mood"
+sampling_scheme: "6x/day 90-minute interval"
+participants: "individuals with residual depressive symptoms"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347473">10.5281/zenodo.17347473</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0010_geschwind")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0010_geschwind")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Geschwind
-- **Year:** 2013
-- **Paper DOI:** [https://doi.org/10.1371/journal.pone.0060188](https://doi.org/10.1371/journal.pone.0060188)
-- **Topics:** depression, neuroticism, mood
-
-## Data Characteristics
-
-- **Participants:** 129 (individuals with residual depressive symptoms)
-- **Time Points:** 200
-- **Days:** 20
-- **Beeps per Day:** 10
-- **Sampling Scheme:** 6x/day 90-minute interval
-- **Raw Timestamp:** no
-- **Implicit Missingness:** no
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Geschwind</li>
+<li><strong>Year:</strong> 2013</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1371/journal.pone.0060188">https://doi.org/10.1371/journal.pone.0060188</a></li>
+<li><strong>Topics:</strong> depression, neuroticism, mood</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 129 (individuals with residual depressive symptoms)</li>
+<li><strong>Time Points:</strong> 200</li>
+<li><strong>Days:</strong> 20</li>
+<li><strong>Beeps per Day:</strong> 10</li>
+<li><strong>Sampling Scheme:</strong> 6x/day 90-minute interval</li>
+<li><strong>Raw Timestamp:</strong> no</li>
+<li><strong>Implicit Missingness:</strong> no</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://doi.org/10.1371/journal.pone.0060188.s004](https://doi.org/10.1371/journal.pone.0060188.s004)
-- **Link to Codebook:** [-](-)
-- **Link to Code:** [https://doi.org/10.1371/journal.pone.0060188.s001](https://doi.org/10.1371/journal.pone.0060188.s001)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347473](https://doi.org/10.5281/zenodo.17347473)
-- **R:** `openesm::get_dataset("0010_geschwind")`
-- **Python:** `openesm.get_dataset("0010_geschwind")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347473">10.5281/zenodo.17347473</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://doi.org/10.1371/journal.pone.0060188.s004">https://doi.org/10.1371/journal.pone.0060188.s004</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="-">-</a></p>
+<p><strong>Code:</strong> <a href="https://doi.org/10.1371/journal.pone.0060188.s001">https://doi.org/10.1371/journal.pone.0060188.s001</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0011_kuppens.md
+++ b/website/content/datasets/0011_kuppens.md
@@ -1,41 +1,66 @@
 ---
 title: "Kuppens (2016)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0011_kuppens"
+first_author: "Kuppens"
+year: 2016
+paper_doi: "https://doi.org/10.1177/1073191116645909"
+zenodo_doi: "10.5281/zenodo.17347412"
+license: "CC BY-NC 4.0"
+n_participants: 95
+n_time_points: 70
+n_days: "7"
+topics: "neuroticism, affect, emotion"
+sampling_scheme: "10x/day random 90-minute intervals"
+participants: "undergraduate students"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347412">10.5281/zenodo.17347412</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0011_kuppens")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0011_kuppens")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Kuppens
-- **Year:** 2016
-- **Paper DOI:** [https://doi.org/10.1177/1073191116645909](https://doi.org/10.1177/1073191116645909)
-- **Topics:** neuroticism, affect, emotion
-
-## Data Characteristics
-
-- **Participants:** 95 (undergraduate students)
-- **Time Points:** 70
-- **Days:** 7
-- **Beeps per Day:** 10
-- **Sampling Scheme:** 10x/day random 90-minute intervals
-- **Raw Timestamp:** no
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Kuppens</li>
+<li><strong>Year:</strong> 2016</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1177/1073191116645909">https://doi.org/10.1177/1073191116645909</a></li>
+<li><strong>Topics:</strong> neuroticism, affect, emotion</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 95 (undergraduate students)</li>
+<li><strong>Time Points:</strong> 70</li>
+<li><strong>Days:</strong> 7</li>
+<li><strong>Beeps per Day:</strong> 10</li>
+<li><strong>Sampling Scheme:</strong> 10x/day random 90-minute intervals</li>
+<li><strong>Raw Timestamp:</strong> no</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://journals-sagepub-com.ezproxy.ub.uni-marburg.de/doi/10.1177/1073191116645909#supplementary-materials](https://journals-sagepub-com.ezproxy.ub.uni-marburg.de/doi/10.1177/1073191116645909#supplementary-materials)
-- **Link to Codebook:** [-](-)
-- **Link to Code:** [https://journals-sagepub-com.ezproxy.ub.uni-marburg.de/doi/10.1177/1073191116645909#supplementary-materials](https://journals-sagepub-com.ezproxy.ub.uni-marburg.de/doi/10.1177/1073191116645909#supplementary-materials)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347412](https://doi.org/10.5281/zenodo.17347412)
-- **R:** `openesm::get_dataset("0011_kuppens")`
-- **Python:** `openesm.get_dataset("0011_kuppens")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347412">10.5281/zenodo.17347412</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://journals-sagepub-com.ezproxy.ub.uni-marburg.de/doi/10.1177/1073191116645909#supplementary-materials">https://journals-sagepub-com.ezproxy.ub.uni-marburg.de/doi/10.1177/1073191116645909#supplementary-materials</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="-">-</a></p>
+<p><strong>Code:</strong> <a href="https://journals-sagepub-com.ezproxy.ub.uni-marburg.de/doi/10.1177/1073191116645909#supplementary-materials">https://journals-sagepub-com.ezproxy.ub.uni-marburg.de/doi/10.1177/1073191116645909#supplementary-materials</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0012_dejonckheere.md
+++ b/website/content/datasets/0012_dejonckheere.md
@@ -1,41 +1,66 @@
 ---
 title: "Dejonckheere (2019)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0012_dejonckheere"
+first_author: "Dejonckheere"
+year: 2019
+paper_doi: "https://doi.org/10.1080/02699931.2018.1524747"
+zenodo_doi: "10.5281/zenodo.17347569"
+license: "CC-BY 4.0"
+n_participants: 100
+n_time_points: 98
+n_days: "14"
+topics: "rumination, depression, emotion regulation, afect"
+sampling_scheme: "7x/day stratified random interval scheme"
+participants: "community sample"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347569">10.5281/zenodo.17347569</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0012_dejonckheere")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0012_dejonckheere")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Dejonckheere
-- **Year:** 2019
-- **Paper DOI:** [https://doi.org/10.1080/02699931.2018.1524747](https://doi.org/10.1080/02699931.2018.1524747)
-- **Topics:** rumination, depression, emotion regulation, afect
-
-## Data Characteristics
-
-- **Participants:** 100 (community sample)
-- **Time Points:** 98
-- **Days:** 14
-- **Beeps per Day:** 7
-- **Sampling Scheme:** 7x/day stratified random interval scheme
-- **Raw Timestamp:** no
-- **Implicit Missingness:** no
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Dejonckheere</li>
+<li><strong>Year:</strong> 2019</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1080/02699931.2018.1524747">https://doi.org/10.1080/02699931.2018.1524747</a></li>
+<li><strong>Topics:</strong> rumination, depression, emotion regulation, afect</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 100 (community sample)</li>
+<li><strong>Time Points:</strong> 98</li>
+<li><strong>Days:</strong> 14</li>
+<li><strong>Beeps per Day:</strong> 7</li>
+<li><strong>Sampling Scheme:</strong> 7x/day stratified random interval scheme</li>
+<li><strong>Raw Timestamp:</strong> no</li>
+<li><strong>Implicit Missingness:</strong> no</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://figshare.com/articles/dataset/Poor_emotion_regulation_ability_mediates_the_link_between_depressive_symptoms_and_affective_bipolarity/7150664](https://figshare.com/articles/dataset/Poor_emotion_regulation_ability_mediates_the_link_between_depressive_symptoms_and_affective_bipolarity/7150664)
-- **Link to Codebook:** [https://osf.io/487eg](https://osf.io/487eg)
-- **Link to Code:** [https://www.tandfonline.com/doi/full/10.1080/02699931.2018.1524747#supplemental-material-section](https://www.tandfonline.com/doi/full/10.1080/02699931.2018.1524747#supplemental-material-section)
 - **License:** CC-BY 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347569](https://doi.org/10.5281/zenodo.17347569)
-- **R:** `openesm::get_dataset("0012_dejonckheere")`
-- **Python:** `openesm.get_dataset("0012_dejonckheere")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347569">10.5281/zenodo.17347569</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://figshare.com/articles/dataset/Poor_emotion_regulation_ability_mediates_the_link_between_depressive_symptoms_and_affective_bipolarity/7150664">https://figshare.com/articles/dataset/Poor_emotion_regulation_ability_mediates_the_link_between_depressive_symptoms_and_affective_bipolarity/7150664</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/487eg">https://osf.io/487eg</a></p>
+<p><strong>Code:</strong> <a href="https://www.tandfonline.com/doi/full/10.1080/02699931.2018.1524747#supplemental-material-section">https://www.tandfonline.com/doi/full/10.1080/02699931.2018.1524747#supplemental-material-section</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0013_hoebeke.md
+++ b/website/content/datasets/0013_hoebeke.md
@@ -1,41 +1,66 @@
 ---
 title: "Hoebeke (2022)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0013_hoebeke"
+first_author: "Hoebeke"
+year: 2022
+paper_doi: "https://doi.org/10.36131/cnfioritieditore20220504"
+zenodo_doi: "10.5281/zenodo.17347619"
+license: "CC-BY 4.0"
+n_participants: 40
+n_time_points: 56
+n_days: "14"
+topics: "rumination, depression, anxiety"
+sampling_scheme: "4x/day time-contingent equidistant intervals"
+participants: "community sample"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347619">10.5281/zenodo.17347619</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0013_hoebeke")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0013_hoebeke")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Hoebeke
-- **Year:** 2022
-- **Paper DOI:** [https://doi.org/10.36131/cnfioritieditore20220504](https://doi.org/10.36131/cnfioritieditore20220504)
-- **Topics:** rumination, depression, anxiety
-
-## Data Characteristics
-
-- **Participants:** 40 (community sample)
-- **Time Points:** 56
-- **Days:** 14
-- **Beeps per Day:** 4
-- **Sampling Scheme:** 4x/day time-contingent equidistant intervals
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** no
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Hoebeke</li>
+<li><strong>Year:</strong> 2022</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.36131/cnfioritieditore20220504">https://doi.org/10.36131/cnfioritieditore20220504</a></li>
+<li><strong>Topics:</strong> rumination, depression, anxiety</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 40 (community sample)</li>
+<li><strong>Time Points:</strong> 56</li>
+<li><strong>Days:</strong> 14</li>
+<li><strong>Beeps per Day:</strong> 4</li>
+<li><strong>Sampling Scheme:</strong> 4x/day time-contingent equidistant intervals</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> no</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/dngyk/](https://osf.io/dngyk/)
-- **Link to Codebook:** [https://osf.io/wj6xn](https://osf.io/wj6xn)
-- **Link to Code:** [https://osf.io/dngyk/](https://osf.io/dngyk/)
 - **License:** CC-BY 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347619](https://doi.org/10.5281/zenodo.17347619)
-- **R:** `openesm::get_dataset("0013_hoebeke")`
-- **Python:** `openesm.get_dataset("0013_hoebeke")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347619">10.5281/zenodo.17347619</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/dngyk/">https://osf.io/dngyk/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/wj6xn">https://osf.io/wj6xn</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/dngyk/">https://osf.io/dngyk/</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0014_habets.md
+++ b/website/content/datasets/0014_habets.md
@@ -1,41 +1,66 @@
 ---
 title: "Habets (2020)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0014_habets"
+first_author: "Habets"
+year: 2020
+paper_doi: "https://doi.org/10.2196/15628"
+zenodo_doi: "10.5281/zenodo.17347440"
+license: "CC0 1.0"
+n_participants: 20
+n_time_points: 98
+n_days: "14"
+topics: "Parkinson, affect, motor symptoms, context"
+sampling_scheme: "7x/day semi-random"
+participants: "patients with Parkinson disease"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347440">10.5281/zenodo.17347440</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0014_habets")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0014_habets")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Habets
-- **Year:** 2020
-- **Paper DOI:** [https://doi.org/10.2196/15628](https://doi.org/10.2196/15628)
-- **Topics:** Parkinson, affect, motor symptoms, context
-
-## Data Characteristics
-
-- **Participants:** 20 (patients with Parkinson disease)
-- **Time Points:** 98
-- **Days:** 14
-- **Beeps per Day:** 7
-- **Sampling Scheme:** 7x/day semi-random
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Habets</li>
+<li><strong>Year:</strong> 2020</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.2196/15628">https://doi.org/10.2196/15628</a></li>
+<li><strong>Topics:</strong> Parkinson, affect, motor symptoms, context</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 20 (patients with Parkinson disease)</li>
+<li><strong>Time Points:</strong> 98</li>
+<li><strong>Days:</strong> 14</li>
+<li><strong>Beeps per Day:</strong> 7</li>
+<li><strong>Sampling Scheme:</strong> 7x/day semi-random</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** no
 - **Passive Sensor Data:** yes
-- **Link to Original Data:** [https://doi.org/10.34894/5HHK8H](https://doi.org/10.34894/5HHK8H)
-- **Link to Codebook:** [https://dataverse.nl/file.xhtml?fileId=36289&version=2.0](https://dataverse.nl/file.xhtml?fileId=36289&version=2.0)
-- **Link to Code:** [https://github.com/jgvhabets/sensor_EMA_PD_monitoring](https://github.com/jgvhabets/sensor_EMA_PD_monitoring)
 - **License:** CC0 1.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347440](https://doi.org/10.5281/zenodo.17347440)
-- **R:** `openesm::get_dataset("0014_habets")`
-- **Python:** `openesm.get_dataset("0014_habets")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347440">10.5281/zenodo.17347440</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://doi.org/10.34894/5HHK8H">https://doi.org/10.34894/5HHK8H</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://dataverse.nl/file.xhtml?fileId=36289&version=2.0">https://dataverse.nl/file.xhtml?fileId=36289&version=2.0</a></p>
+<p><strong>Code:</strong> <a href="https://github.com/jgvhabets/sensor_EMA_PD_monitoring">https://github.com/jgvhabets/sensor_EMA_PD_monitoring</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0015_flueckiger.md
+++ b/website/content/datasets/0015_flueckiger.md
@@ -1,41 +1,66 @@
 ---
 title: "Flueckiger (2014)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0015_flueckiger"
+first_author: "Flueckiger"
+year: 2014
+paper_doi: "https://doi.org/10.1371/journal.pone.0111080"
+zenodo_doi: "10.5281/zenodo.17347647"
+license: "CC0 1.0"
+n_participants: 72
+n_time_points: 32
+n_days: "32"
+topics: "health behavior, depression, academic performance, affect"
+sampling_scheme: "1x/day at 5pm"
+participants: "first-year psychology students"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347647">10.5281/zenodo.17347647</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0015_flueckiger")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0015_flueckiger")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Flueckiger
-- **Year:** 2014
-- **Paper DOI:** [https://doi.org/10.1371/journal.pone.0111080](https://doi.org/10.1371/journal.pone.0111080)
-- **Topics:** health behavior, depression, academic performance, affect
-
-## Data Characteristics
-
-- **Participants:** 72 (first-year psychology students)
-- **Time Points:** 32
-- **Days:** 32
-- **Beeps per Day:** 1
-- **Sampling Scheme:** 1x/day at 5pm
-- **Raw Timestamp:** no
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Flueckiger</li>
+<li><strong>Year:</strong> 2014</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1371/journal.pone.0111080">https://doi.org/10.1371/journal.pone.0111080</a></li>
+<li><strong>Topics:</strong> health behavior, depression, academic performance, affect</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 72 (first-year psychology students)</li>
+<li><strong>Time Points:</strong> 32</li>
+<li><strong>Days:</strong> 32</li>
+<li><strong>Beeps per Day:</strong> 1</li>
+<li><strong>Sampling Scheme:</strong> 1x/day at 5pm</li>
+<li><strong>Raw Timestamp:</strong> no</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/27388](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/27388)
-- **Link to Codebook:** [https://doi.org/10.7910/DVN/27388/U8IPJZ](https://doi.org/10.7910/DVN/27388/U8IPJZ)
-- **Link to Code:** [null](null)
 - **License:** CC0 1.0
 
-## Data Access
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347647">10.5281/zenodo.17347647</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/27388">https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/27388</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://doi.org/10.7910/DVN/27388/U8IPJZ">https://doi.org/10.7910/DVN/27388/U8IPJZ</a></p>
 
-- **Zenodo DOI:** [10.5281/zenodo.17347647](https://doi.org/10.5281/zenodo.17347647)
-- **R:** `openesm::get_dataset("0015_flueckiger")`
-- **Python:** `openesm.get_dataset("0015_flueckiger")`
+</div>
 
 
 

--- a/website/content/datasets/0017_jang.md
+++ b/website/content/datasets/0017_jang.md
@@ -1,41 +1,66 @@
 ---
 title: "Jang (2024)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0017_jang"
+first_author: "Jang"
+year: 2024
+paper_doi: "https://doi.org/10.1038/s41597-024-04147-6"
+zenodo_doi: "10.5281/zenodo.17347469"
+license: "CC-BY 4.0"
+n_participants: 43
+n_time_points: 402
+n_days: "402"
+topics: "panic symptoms, digital phenotyping, behavior"
+sampling_scheme: "1x/day in the evening"
+participants: "patients diagnosed with mood disorders, anxiety disorders, trauma and stressor-related disorders, and obsessive-compulsive and related disorder"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347469">10.5281/zenodo.17347469</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0017_jang")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0017_jang")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Jang
-- **Year:** 2024
-- **Paper DOI:** [https://doi.org/10.1038/s41597-024-04147-6](https://doi.org/10.1038/s41597-024-04147-6)
-- **Topics:** panic symptoms, digital phenotyping, behavior
-
-## Data Characteristics
-
-- **Participants:** 43 (patients diagnosed with mood disorders, anxiety disorders, trauma and stressor-related disorders, and obsessive-compulsive and related disorder)
-- **Time Points:** 402
-- **Days:** 402
-- **Beeps per Day:** 1
-- **Sampling Scheme:** 1x/day in the evening
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Jang</li>
+<li><strong>Year:</strong> 2024</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1038/s41597-024-04147-6">https://doi.org/10.1038/s41597-024-04147-6</a></li>
+<li><strong>Topics:</strong> panic symptoms, digital phenotyping, behavior</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 43 (patients diagnosed with mood disorders, anxiety disorders, trauma and stressor-related disorders, and obsessive-compulsive and related disorder)</li>
+<li><strong>Time Points:</strong> 402</li>
+<li><strong>Days:</strong> 402</li>
+<li><strong>Beeps per Day:</strong> 1</li>
+<li><strong>Sampling Scheme:</strong> 1x/day in the evening</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** yes
-- **Link to Original Data:** [https://zenodo.org/records/14190139](https://zenodo.org/records/14190139)
-- **Link to Codebook:** [https://static-content.springer.com/esm/art%3A10.1038%2Fs41597-024-04147-6/MediaObjects/41597_2024_4147_MOESM1_ESM.pdf](https://static-content.springer.com/esm/art%3A10.1038%2Fs41597-024-04147-6/MediaObjects/41597_2024_4147_MOESM1_ESM.pdf)
-- **Link to Code:** [https://github.com/DigitalHealthcareLab/24PanicPrediction](https://github.com/DigitalHealthcareLab/24PanicPrediction)
 - **License:** CC-BY 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347469](https://doi.org/10.5281/zenodo.17347469)
-- **R:** `openesm::get_dataset("0017_jang")`
-- **Python:** `openesm.get_dataset("0017_jang")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347469">10.5281/zenodo.17347469</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://zenodo.org/records/14190139">https://zenodo.org/records/14190139</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://static-content.springer.com/esm/art%3A10.1038%2Fs41597-024-04147-6/MediaObjects/41597_2024_4147_MOESM1_ESM.pdf">https://static-content.springer.com/esm/art%3A10.1038%2Fs41597-024-04147-6/MediaObjects/41597_2024_4147_MOESM1_ESM.pdf</a></p>
+<p><strong>Code:</strong> <a href="https://github.com/DigitalHealthcareLab/24PanicPrediction">https://github.com/DigitalHealthcareLab/24PanicPrediction</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0018_bailon.md
+++ b/website/content/datasets/0018_bailon.md
@@ -1,41 +1,66 @@
 ---
 title: "Bailon (2020)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0018_bailon"
+first_author: "Bailon"
+year: 2020
+paper_doi: "https://doi.org/10.1038/s41597-020-00700-1"
+zenodo_doi: "10.5281/zenodo.17347690"
+license: "CC-BY 4.0"
+n_participants: 999
+n_time_points: 444
+n_days: "86"
+topics: "COVID, affect, pandemic, valence, arousal, context"
+sampling_scheme: "6x/day pseudo-random one-hour intervals"
+participants: "community sample"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347690">10.5281/zenodo.17347690</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0018_bailon")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0018_bailon")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Bailon
-- **Year:** 2020
-- **Paper DOI:** [https://doi.org/10.1038/s41597-020-00700-1](https://doi.org/10.1038/s41597-020-00700-1)
-- **Topics:** COVID, affect, pandemic, valence, arousal, context
-
-## Data Characteristics
-
-- **Participants:** 999 (community sample)
-- **Time Points:** 444
-- **Days:** 86
-- **Beeps per Day:** 6
-- **Sampling Scheme:** 6x/day pseudo-random one-hour intervals
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Bailon</li>
+<li><strong>Year:</strong> 2020</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1038/s41597-020-00700-1">https://doi.org/10.1038/s41597-020-00700-1</a></li>
+<li><strong>Topics:</strong> COVID, affect, pandemic, valence, arousal, context</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 999 (community sample)</li>
+<li><strong>Time Points:</strong> 444</li>
+<li><strong>Days:</strong> 86</li>
+<li><strong>Beeps per Day:</strong> 6</li>
+<li><strong>Sampling Scheme:</strong> 6x/day pseudo-random one-hour intervals</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [http://doi.org/10.5281/zenodo.3774526](http://doi.org/10.5281/zenodo.3774526)
-- **Link to Codebook:** [https://zenodo.org/records/4024141](https://zenodo.org/records/4024141)
-- **Link to Code:** [null](null)
 - **License:** CC-BY 4.0
 
-## Data Access
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347690">10.5281/zenodo.17347690</a></p>
+<p><strong>Original Source Data:</strong> <a href="http://doi.org/10.5281/zenodo.3774526">http://doi.org/10.5281/zenodo.3774526</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://zenodo.org/records/4024141">https://zenodo.org/records/4024141</a></p>
 
-- **Zenodo DOI:** [10.5281/zenodo.17347690](https://doi.org/10.5281/zenodo.17347690)
-- **R:** `openesm::get_dataset("0018_bailon")`
-- **Python:** `openesm.get_dataset("0018_bailon")`
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0019_soederberg.md
+++ b/website/content/datasets/0019_soederberg.md
@@ -1,41 +1,66 @@
 ---
 title: "Söderberg (2024)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0019_soederberg"
+first_author: "Söderberg"
+year: 2024
+paper_doi: "https://doi.org/10.12688/f1000research.157148.1"
+zenodo_doi: "10.5281/zenodo.17347732"
+license: "CC-BY 4.0"
+n_participants: 302
+n_time_points: 40
+n_days: "10"
+topics: "schooling, relationships, self-efficacy, emotions, sleep"
+sampling_scheme: "4x/day fixed and random sampling"
+participants: "middle and secondary school students"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347732">10.5281/zenodo.17347732</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0019_soederberg")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0019_soederberg")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Söderberg
-- **Year:** 2024
-- **Paper DOI:** [https://doi.org/10.12688/f1000research.157148.1](https://doi.org/10.12688/f1000research.157148.1)
-- **Topics:** schooling, relationships, self-efficacy, emotions, sleep
-
-## Data Characteristics
-
-- **Participants:** 302 (middle and secondary school students)
-- **Time Points:** 40
-- **Days:** 10
-- **Beeps per Day:** 4
-- **Sampling Scheme:** 4x/day fixed and random sampling
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** no
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Söderberg</li>
+<li><strong>Year:</strong> 2024</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.12688/f1000research.157148.1">https://doi.org/10.12688/f1000research.157148.1</a></li>
+<li><strong>Topics:</strong> schooling, relationships, self-efficacy, emotions, sleep</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 302 (middle and secondary school students)</li>
+<li><strong>Time Points:</strong> 40</li>
+<li><strong>Days:</strong> 10</li>
+<li><strong>Beeps per Day:</strong> 4</li>
+<li><strong>Sampling Scheme:</strong> 4x/day fixed and random sampling</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> no</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://doi.org/10.5281/zenodo.13332148](https://doi.org/10.5281/zenodo.13332148)
-- **Link to Codebook:** [https://zenodo.org/records/13332148](https://zenodo.org/records/13332148)
-- **Link to Code:** [null](null)
 - **License:** CC-BY 4.0
 
-## Data Access
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347732">10.5281/zenodo.17347732</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://doi.org/10.5281/zenodo.13332148">https://doi.org/10.5281/zenodo.13332148</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://zenodo.org/records/13332148">https://zenodo.org/records/13332148</a></p>
 
-- **Zenodo DOI:** [10.5281/zenodo.17347732](https://doi.org/10.5281/zenodo.17347732)
-- **R:** `openesm::get_dataset("0019_soederberg")`
-- **Python:** `openesm.get_dataset("0019_soederberg")`
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0021_gundogdu.md
+++ b/website/content/datasets/0021_gundogdu.md
@@ -1,41 +1,66 @@
 ---
 title: "Gundogdu (2017)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0021_gundogdu"
+first_author: "Gundogdu"
+year: 2017
+paper_doi: "https://doi.org/10.1098/rsos.170194"
+zenodo_doi: "10.5281/zenodo.17347760"
+license: "CC0 1.0"
+n_participants: 54
+n_time_points: 90
+n_days: "30"
+topics: "social interactions, personality states, personality"
+sampling_scheme: "3x/day fixed schedule"
+participants: "employees of research center"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347760">10.5281/zenodo.17347760</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0021_gundogdu")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0021_gundogdu")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Gundogdu
-- **Year:** 2017
-- **Paper DOI:** [https://doi.org/10.1098/rsos.170194](https://doi.org/10.1098/rsos.170194)
-- **Topics:** social interactions, personality states, personality
-
-## Data Characteristics
-
-- **Participants:** 54 (employees of research center)
-- **Time Points:** 90
-- **Days:** 30
-- **Beeps per Day:** 3
-- **Sampling Scheme:** 3x/day fixed schedule
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Gundogdu</li>
+<li><strong>Year:</strong> 2017</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1098/rsos.170194">https://doi.org/10.1098/rsos.170194</a></li>
+<li><strong>Topics:</strong> social interactions, personality states, personality</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 54 (employees of research center)</li>
+<li><strong>Time Points:</strong> 90</li>
+<li><strong>Days:</strong> 30</li>
+<li><strong>Beeps per Day:</strong> 3</li>
+<li><strong>Sampling Scheme:</strong> 3x/day fixed schedule</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** no
 - **Passive Sensor Data:** yes
-- **Link to Original Data:** [https://doi.org/10.5061/dryad.b88c7](https://doi.org/10.5061/dryad.b88c7)
-- **Link to Codebook:** [https://datadryad.org/stash/dataset/doi:10.5061/dryad.b88c7#usage](https://datadryad.org/stash/dataset/doi:10.5061/dryad.b88c7#usage)
-- **Link to Code:** [https://github.com/didemgundogdu/RoyalOpenSciencePersonalityDynamics](https://github.com/didemgundogdu/RoyalOpenSciencePersonalityDynamics)
 - **License:** CC0 1.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347760](https://doi.org/10.5281/zenodo.17347760)
-- **R:** `openesm::get_dataset("0021_gundogdu")`
-- **Python:** `openesm.get_dataset("0021_gundogdu")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347760">10.5281/zenodo.17347760</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://doi.org/10.5061/dryad.b88c7">https://doi.org/10.5061/dryad.b88c7</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://datadryad.org/stash/dataset/doi:10.5061/dryad.b88c7#usage">https://datadryad.org/stash/dataset/doi:10.5061/dryad.b88c7#usage</a></p>
+<p><strong>Code:</strong> <a href="https://github.com/didemgundogdu/RoyalOpenSciencePersonalityDynamics">https://github.com/didemgundogdu/RoyalOpenSciencePersonalityDynamics</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0022_menghini.md
+++ b/website/content/datasets/0022_menghini.md
@@ -1,41 +1,66 @@
 ---
 title: "Menghini (2023)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0022_menghini"
+first_author: "Menghini"
+year: 2023
+paper_doi: "https://doi.org/10.1027/1015-5759/a000725"
+zenodo_doi: "10.5281/zenodo.17347537"
+license: "GPL-3.0"
+n_participants: 139
+n_time_points: 21
+n_days: "3"
+topics: "workplace stress, mood"
+sampling_scheme: "7x/day random schedule"
+participants: "full-time office workers"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347537">10.5281/zenodo.17347537</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0022_menghini")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0022_menghini")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Menghini
-- **Year:** 2023
-- **Paper DOI:** [https://doi.org/10.1027/1015-5759/a000725](https://doi.org/10.1027/1015-5759/a000725)
-- **Topics:** workplace stress, mood
-
-## Data Characteristics
-
-- **Participants:** 139 (full-time office workers)
-- **Time Points:** 21
-- **Days:** 3
-- **Beeps per Day:** 7
-- **Sampling Scheme:** 7x/day random schedule
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** no
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Menghini</li>
+<li><strong>Year:</strong> 2023</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1027/1015-5759/a000725">https://doi.org/10.1027/1015-5759/a000725</a></li>
+<li><strong>Topics:</strong> workplace stress, mood</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 139 (full-time office workers)</li>
+<li><strong>Time Points:</strong> 21</li>
+<li><strong>Days:</strong> 3</li>
+<li><strong>Beeps per Day:</strong> 7</li>
+<li><strong>Sampling Scheme:</strong> 7x/day random schedule</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> no</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://github.com/Luca-Menghini/ESMscales-workplaceStress](https://github.com/Luca-Menghini/ESMscales-workplaceStress)
-- **Link to Codebook:** [https://osf.io/87a9p/files/osfstorage](https://osf.io/87a9p/files/osfstorage)
-- **Link to Code:** [https://github.com/Luca-Menghini/ESMscales-workplaceStress/tree/main/S3_dataAnalysis](https://github.com/Luca-Menghini/ESMscales-workplaceStress/tree/main/S3_dataAnalysis)
 - **License:** GPL-3.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347537](https://doi.org/10.5281/zenodo.17347537)
-- **R:** `openesm::get_dataset("0022_menghini")`
-- **Python:** `openesm.get_dataset("0022_menghini")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347537">10.5281/zenodo.17347537</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://github.com/Luca-Menghini/ESMscales-workplaceStress">https://github.com/Luca-Menghini/ESMscales-workplaceStress</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/87a9p/files/osfstorage">https://osf.io/87a9p/files/osfstorage</a></p>
+<p><strong>Code:</strong> <a href="https://github.com/Luca-Menghini/ESMscales-workplaceStress/tree/main/S3_dataAnalysis">https://github.com/Luca-Menghini/ESMscales-workplaceStress/tree/main/S3_dataAnalysis</a></p>
+</div>
 
 
 

--- a/website/content/datasets/0023_dora.md
+++ b/website/content/datasets/0023_dora.md
@@ -1,41 +1,66 @@
 ---
 title: "Dora (2024)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0023_dora"
+first_author: "Dora"
+year: 2024
+paper_doi: "https://doi.org/10.31234/osf.io/jc938"
+zenodo_doi: "10.5281/zenodo.17347813"
+license: "CC-BY 4.0"
+n_participants: 213
+n_time_points: 63
+n_days: "22"
+topics: "alcohol, self-control demands, intoxication, substance use"
+sampling_scheme: "3x/day or 5x/day unclear schedule"
+participants: "undergraduate students"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347813">10.5281/zenodo.17347813</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0023_dora")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0023_dora")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Dora
-- **Year:** 2024
-- **Paper DOI:** [https://doi.org/10.31234/osf.io/jc938](https://doi.org/10.31234/osf.io/jc938)
-- **Topics:** alcohol, self-control demands, intoxication, substance use
-
-## Data Characteristics
-
-- **Participants:** 213 (undergraduate students)
-- **Time Points:** 63
-- **Days:** 22
-- **Beeps per Day:** 3 or 5
-- **Sampling Scheme:** 3x/day or 5x/day unclear schedule
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Dora</li>
+<li><strong>Year:</strong> 2024</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.31234/osf.io/jc938">https://doi.org/10.31234/osf.io/jc938</a></li>
+<li><strong>Topics:</strong> alcohol, self-control demands, intoxication, substance use</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 213 (undergraduate students)</li>
+<li><strong>Time Points:</strong> 63</li>
+<li><strong>Days:</strong> 22</li>
+<li><strong>Beeps per Day:</strong> 3 or 5</li>
+<li><strong>Sampling Scheme:</strong> 3x/day or 5x/day unclear schedule</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/rh2sw/](https://osf.io/rh2sw/)
-- **Link to Codebook:** [https://osf.io/zy639](https://osf.io/zy639)
-- **Link to Code:** [https://osf.io/zy639](https://osf.io/zy639)
 - **License:** CC-BY 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347813](https://doi.org/10.5281/zenodo.17347813)
-- **R:** `openesm::get_dataset("0023_dora")`
-- **Python:** `openesm.get_dataset("0023_dora")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347813">10.5281/zenodo.17347813</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/rh2sw/">https://osf.io/rh2sw/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/zy639">https://osf.io/zy639</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/zy639">https://osf.io/zy639</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0024_hasselhorn.md
+++ b/website/content/datasets/0024_hasselhorn.md
@@ -1,41 +1,66 @@
 ---
 title: "Hasselhorn (2021)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0024_hasselhorn"
+first_author: "Hasselhorn"
+year: 2021
+paper_doi: "https://doi.org/10.3758/s13428-021-01683-6"
+zenodo_doi: "10.5281/zenodo.17347856"
+license: "CC BY-NC 4.0"
+n_participants: 313
+n_time_points: 84
+n_days: "14"
+topics: "sampling frequency, affect, compliance, extraversion, perceived burden"
+sampling_scheme: "9x/day or 3x/day subject-specific schedule"
+participants: "university students"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347856">10.5281/zenodo.17347856</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0024_hasselhorn")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0024_hasselhorn")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Hasselhorn
-- **Year:** 2021
-- **Paper DOI:** [https://doi.org/10.3758/s13428-021-01683-6](https://doi.org/10.3758/s13428-021-01683-6)
-- **Topics:** sampling frequency, affect, compliance, extraversion, perceived burden
-
-## Data Characteristics
-
-- **Participants:** 313 (university students)
-- **Time Points:** 84
-- **Days:** 14
-- **Beeps per Day:** 3 or 9
-- **Sampling Scheme:** 9x/day or 3x/day subject-specific schedule
-- **Raw Timestamp:** no
-- **Implicit Missingness:** unclear
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Hasselhorn</li>
+<li><strong>Year:</strong> 2021</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.3758/s13428-021-01683-6">https://doi.org/10.3758/s13428-021-01683-6</a></li>
+<li><strong>Topics:</strong> sampling frequency, affect, compliance, extraversion, perceived burden</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 313 (university students)</li>
+<li><strong>Time Points:</strong> 84</li>
+<li><strong>Days:</strong> 14</li>
+<li><strong>Beeps per Day:</strong> 3 or 9</li>
+<li><strong>Sampling Scheme:</strong> 9x/day or 3x/day subject-specific schedule</li>
+<li><strong>Raw Timestamp:</strong> no</li>
+<li><strong>Implicit Missingness:</strong> unclear</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/vw3gf/?view_only=b6f9f08a6b5941eb9c17a4951d1d0cd2;](https://osf.io/vw3gf/?view_only=b6f9f08a6b5941eb9c17a4951d1d0cd2;)
-- **Link to Codebook:** [https://osf.io/ze9wn](https://osf.io/ze9wn)
-- **Link to Code:** [https://osf.io/vw3gf/?view_only=b6f9f08a6b5941eb9c17a4951d1d0cd2;](https://osf.io/vw3gf/?view_only=b6f9f08a6b5941eb9c17a4951d1d0cd2;)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347856](https://doi.org/10.5281/zenodo.17347856)
-- **R:** `openesm::get_dataset("0024_hasselhorn")`
-- **Python:** `openesm.get_dataset("0024_hasselhorn")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347856">10.5281/zenodo.17347856</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/vw3gf/?view_only=b6f9f08a6b5941eb9c17a4951d1d0cd2;">https://osf.io/vw3gf/?view_only=b6f9f08a6b5941eb9c17a4951d1d0cd2;</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/ze9wn">https://osf.io/ze9wn</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/vw3gf/?view_only=b6f9f08a6b5941eb9c17a4951d1d0cd2;">https://osf.io/vw3gf/?view_only=b6f9f08a6b5941eb9c17a4951d1d0cd2;</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0025_hasselhorn.md
+++ b/website/content/datasets/0025_hasselhorn.md
@@ -1,41 +1,66 @@
 ---
 title: "Hasselhorn (2021)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0025_hasselhorn"
+first_author: "Hasselhorn"
+year: 2021
+paper_doi: "https://doi.org/10.3758/s13428-021-01683-6"
+zenodo_doi: "10.5281/zenodo.17347567"
+license: "CC BY-NC 4.0"
+n_participants: 282
+n_time_points: 42
+n_days: "14"
+topics: "questionnaire length, affect, extraversion, perceived burden"
+sampling_scheme: "3x/day fixed schedule"
+participants: "university students"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347567">10.5281/zenodo.17347567</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0025_hasselhorn")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0025_hasselhorn")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Hasselhorn
-- **Year:** 2021
-- **Paper DOI:** [https://doi.org/10.3758/s13428-021-01683-6](https://doi.org/10.3758/s13428-021-01683-6)
-- **Topics:** questionnaire length, affect, extraversion, perceived burden
-
-## Data Characteristics
-
-- **Participants:** 282 (university students)
-- **Time Points:** 42
-- **Days:** 14
-- **Beeps per Day:** 3
-- **Sampling Scheme:** 3x/day fixed schedule
-- **Raw Timestamp:** no
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Hasselhorn</li>
+<li><strong>Year:</strong> 2021</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.3758/s13428-021-01683-6">https://doi.org/10.3758/s13428-021-01683-6</a></li>
+<li><strong>Topics:</strong> questionnaire length, affect, extraversion, perceived burden</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 282 (university students)</li>
+<li><strong>Time Points:</strong> 42</li>
+<li><strong>Days:</strong> 14</li>
+<li><strong>Beeps per Day:</strong> 3</li>
+<li><strong>Sampling Scheme:</strong> 3x/day fixed schedule</li>
+<li><strong>Raw Timestamp:</strong> no</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/vw3gf/](https://osf.io/vw3gf/)
-- **Link to Codebook:** [https://osf.io/23db5?view_only=6e6bf509c6374759b56faac680c55825](https://osf.io/23db5?view_only=6e6bf509c6374759b56faac680c55825)
-- **Link to Code:** [https://osf.io/vw3gf/?view_only=b6f9f08a6b5941eb9c17a4951d1d0cd2;](https://osf.io/vw3gf/?view_only=b6f9f08a6b5941eb9c17a4951d1d0cd2;)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347567](https://doi.org/10.5281/zenodo.17347567)
-- **R:** `openesm::get_dataset("0025_hasselhorn")`
-- **Python:** `openesm.get_dataset("0025_hasselhorn")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347567">10.5281/zenodo.17347567</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/vw3gf/">https://osf.io/vw3gf/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/23db5?view_only=6e6bf509c6374759b56faac680c55825">https://osf.io/23db5?view_only=6e6bf509c6374759b56faac680c55825</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/vw3gf/?view_only=b6f9f08a6b5941eb9c17a4951d1d0cd2;">https://osf.io/vw3gf/?view_only=b6f9f08a6b5941eb9c17a4951d1d0cd2;</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0026_fernandez.md
+++ b/website/content/datasets/0026_fernandez.md
@@ -1,41 +1,66 @@
 ---
 title: "Fernández (2025)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0026_fernandez"
+first_author: "Fernández"
+year: 2025
+paper_doi: "https://doi.org/10.31234/osf.io/uj6df"
+zenodo_doi: "10.5281/zenodo.17347879"
+license: "CC BY-NC 4.0"
+n_participants: 225
+n_time_points: 50
+n_days: "10"
+topics: "well-being, smartphone usage, social media"
+sampling_scheme: "5x/day semi-random signal contingent"
+participants: "young adults (18-25)"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347879">10.5281/zenodo.17347879</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0026_fernandez")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0026_fernandez")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Fernández
-- **Year:** 2025
-- **Paper DOI:** [https://doi.org/10.31234/osf.io/uj6df](https://doi.org/10.31234/osf.io/uj6df)
-- **Topics:** well-being, smartphone usage, social media
-
-## Data Characteristics
-
-- **Participants:** 225 (young adults (18-25))
-- **Time Points:** 50
-- **Days:** 10
-- **Beeps per Day:** 5
-- **Sampling Scheme:** 5x/day semi-random signal contingent
-- **Raw Timestamp:** no
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Fernández</li>
+<li><strong>Year:</strong> 2025</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.31234/osf.io/uj6df">https://doi.org/10.31234/osf.io/uj6df</a></li>
+<li><strong>Topics:</strong> well-being, smartphone usage, social media</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 225 (young adults (18-25))</li>
+<li><strong>Time Points:</strong> 50</li>
+<li><strong>Days:</strong> 10</li>
+<li><strong>Beeps per Day:</strong> 5</li>
+<li><strong>Sampling Scheme:</strong> 5x/day semi-random signal contingent</li>
+<li><strong>Raw Timestamp:</strong> no</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** yes
-- **Link to Original Data:** [https://osf.io/jvms7](https://osf.io/jvms7)
-- **Link to Codebook:** [https://osf.io/w3vp5](https://osf.io/w3vp5)
-- **Link to Code:** [https://osf.io/95ncg](https://osf.io/95ncg)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347879](https://doi.org/10.5281/zenodo.17347879)
-- **R:** `openesm::get_dataset("0026_fernandez")`
-- **Python:** `openesm.get_dataset("0026_fernandez")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347879">10.5281/zenodo.17347879</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/jvms7">https://osf.io/jvms7</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/w3vp5">https://osf.io/w3vp5</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/95ncg">https://osf.io/95ncg</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0027_pavani.md
+++ b/website/content/datasets/0027_pavani.md
@@ -1,41 +1,66 @@
 ---
 title: "Pavani (2017)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0027_pavani"
+first_author: "Pavani"
+year: 2017
+paper_doi: "https://doi.org/10.1002/per.2109"
+zenodo_doi: "10.5281/zenodo.17347892"
+license: "CC BY-NC 4.0"
+n_participants: 78
+n_time_points: 70
+n_days: "14"
+topics: "affect regulation, affect, personality"
+sampling_scheme: "5x/day fixed-schedule with personalization"
+participants: "non-clinical individuals"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347892">10.5281/zenodo.17347892</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0027_pavani")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0027_pavani")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Pavani
-- **Year:** 2017
-- **Paper DOI:** [https://doi.org/10.1002/per.2109](https://doi.org/10.1002/per.2109)
-- **Topics:** affect regulation, affect, personality
-
-## Data Characteristics
-
-- **Participants:** 78 (non-clinical individuals)
-- **Time Points:** 70
-- **Days:** 14
-- **Beeps per Day:** 5
-- **Sampling Scheme:** 5x/day fixed-schedule with personalization
-- **Raw Timestamp:** no
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Pavani</li>
+<li><strong>Year:</strong> 2017</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1002/per.2109">https://doi.org/10.1002/per.2109</a></li>
+<li><strong>Topics:</strong> affect regulation, affect, personality</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 78 (non-clinical individuals)</li>
+<li><strong>Time Points:</strong> 70</li>
+<li><strong>Days:</strong> 14</li>
+<li><strong>Beeps per Day:</strong> 5</li>
+<li><strong>Sampling Scheme:</strong> 5x/day fixed-schedule with personalization</li>
+<li><strong>Raw Timestamp:</strong> no</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/s3chz/?view_only=](https://osf.io/s3chz/?view_only=)
-- **Link to Codebook:** [https://osf.io/u95vg](https://osf.io/u95vg)
-- **Link to Code:** [https://osf.io/s3chz/?view_only=](https://osf.io/s3chz/?view_only=)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347892](https://doi.org/10.5281/zenodo.17347892)
-- **R:** `openesm::get_dataset("0027_pavani")`
-- **Python:** `openesm.get_dataset("0027_pavani")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347892">10.5281/zenodo.17347892</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/s3chz/?view_only=">https://osf.io/s3chz/?view_only=</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/u95vg">https://osf.io/u95vg</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/s3chz/?view_only=">https://osf.io/s3chz/?view_only=</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0028_contreras.md
+++ b/website/content/datasets/0028_contreras.md
@@ -1,41 +1,66 @@
 ---
 title: "Contreras (2020)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0028_contreras"
+first_author: "Contreras"
+year: 2020
+paper_doi: "https://doi.org/10.3389/fpsyg.2020.544565"
+zenodo_doi: "10.5281/zenodo.17347605"
+license: "CC-BY 4.0"
+n_participants: 23
+n_time_points: 70
+n_days: "7"
+topics: "paranoia, sadness, closeness to others, avoidance"
+sampling_scheme: "10x/day stratified sampling"
+participants: "participants with above-average paranoid ideation and/or interpersonal sensitivity"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347605">10.5281/zenodo.17347605</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0028_contreras")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0028_contreras")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Contreras
-- **Year:** 2020
-- **Paper DOI:** [https://doi.org/10.3389/fpsyg.2020.544565](https://doi.org/10.3389/fpsyg.2020.544565)
-- **Topics:** paranoia, sadness, closeness to others, avoidance
-
-## Data Characteristics
-
-- **Participants:** 23 (participants with above-average paranoid ideation and/or interpersonal sensitivity)
-- **Time Points:** 70
-- **Days:** 7
-- **Beeps per Day:** 10
-- **Sampling Scheme:** 10x/day stratified sampling
-- **Raw Timestamp:** no
-- **Implicit Missingness:** no
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Contreras</li>
+<li><strong>Year:</strong> 2020</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.3389/fpsyg.2020.544565">https://doi.org/10.3389/fpsyg.2020.544565</a></li>
+<li><strong>Topics:</strong> paranoia, sadness, closeness to others, avoidance</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 23 (participants with above-average paranoid ideation and/or interpersonal sensitivity)</li>
+<li><strong>Time Points:</strong> 70</li>
+<li><strong>Days:</strong> 7</li>
+<li><strong>Beeps per Day:</strong> 10</li>
+<li><strong>Sampling Scheme:</strong> 10x/day stratified sampling</li>
+<li><strong>Raw Timestamp:</strong> no</li>
+<li><strong>Implicit Missingness:</strong> no</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** no
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/7tk4b/](https://osf.io/7tk4b/)
-- **Link to Codebook:** [https://osf.io/bkn3y](https://osf.io/bkn3y)
-- **Link to Code:** [https://osf.io/mezgw](https://osf.io/mezgw)
 - **License:** CC-BY 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347605](https://doi.org/10.5281/zenodo.17347605)
-- **R:** `openesm::get_dataset("0028_contreras")`
-- **Python:** `openesm.get_dataset("0028_contreras")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347605">10.5281/zenodo.17347605</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/7tk4b/">https://osf.io/7tk4b/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/bkn3y">https://osf.io/bkn3y</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/mezgw">https://osf.io/mezgw</a></p>
+</div>
 
 
 

--- a/website/content/datasets/0029_drukker.md
+++ b/website/content/datasets/0029_drukker.md
@@ -1,41 +1,66 @@
 ---
 title: "Drukker (2020)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0029_drukker"
+first_author: "Drukker"
+year: 2020
+paper_doi: "https://doi.org/10.1016/j.jpsychores.2020.110261"
+zenodo_doi: "10.5281/zenodo.17347944"
+license: "CC BY-NC 4.0"
+n_participants: 24
+n_time_points: 70
+n_days: "7"
+topics: "irritable bowel syndrome, panic disorder, gastrointestinal symptoms, childhood trauma"
+sampling_scheme: "10x/day random schedule"
+participants: "individuals with IBS and panic disorder"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347944">10.5281/zenodo.17347944</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0029_drukker")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0029_drukker")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Drukker
-- **Year:** 2020
-- **Paper DOI:** [https://doi.org/10.1016/j.jpsychores.2020.110261](https://doi.org/10.1016/j.jpsychores.2020.110261)
-- **Topics:** irritable bowel syndrome, panic disorder, gastrointestinal symptoms, childhood trauma
-
-## Data Characteristics
-
-- **Participants:** 24 (individuals with IBS and panic disorder)
-- **Time Points:** 70
-- **Days:** 7
-- **Beeps per Day:** 10
-- **Sampling Scheme:** 10x/day random schedule
-- **Raw Timestamp:** no
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Drukker</li>
+<li><strong>Year:</strong> 2020</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1016/j.jpsychores.2020.110261">https://doi.org/10.1016/j.jpsychores.2020.110261</a></li>
+<li><strong>Topics:</strong> irritable bowel syndrome, panic disorder, gastrointestinal symptoms, childhood trauma</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 24 (individuals with IBS and panic disorder)</li>
+<li><strong>Time Points:</strong> 70</li>
+<li><strong>Days:</strong> 7</li>
+<li><strong>Beeps per Day:</strong> 10</li>
+<li><strong>Sampling Scheme:</strong> 10x/day random schedule</li>
+<li><strong>Raw Timestamp:</strong> no</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://www.sciencedirect.com/science/article/pii/S0022399920308230?via%3Dihub#s0125](https://www.sciencedirect.com/science/article/pii/S0022399920308230?via%3Dihub#s0125)
-- **Link to Codebook:** [https://www.sciencedirect.com/science/article/pii/S0022399920308230?via%3Dihub#s0120](https://www.sciencedirect.com/science/article/pii/S0022399920308230?via%3Dihub#s0120)
-- **Link to Code:** [null](null)
 - **License:** CC BY-NC 4.0
 
-## Data Access
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347944">10.5281/zenodo.17347944</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://www.sciencedirect.com/science/article/pii/S0022399920308230?via%3Dihub#s0125">https://www.sciencedirect.com/science/article/pii/S0022399920308230?via%3Dihub#s0125</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://www.sciencedirect.com/science/article/pii/S0022399920308230?via%3Dihub#s0120">https://www.sciencedirect.com/science/article/pii/S0022399920308230?via%3Dihub#s0120</a></p>
 
-- **Zenodo DOI:** [10.5281/zenodo.17347944](https://doi.org/10.5281/zenodo.17347944)
-- **R:** `openesm::get_dataset("0029_drukker")`
-- **Python:** `openesm.get_dataset("0029_drukker")`
+</div>
 
 
 

--- a/website/content/datasets/0031_koval.md
+++ b/website/content/datasets/0031_koval.md
@@ -1,41 +1,66 @@
 ---
 title: "Koval (2013)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0031_koval"
+first_author: "Koval"
+year: 2013
+paper_doi: "http://doi.org/10.1037/a0033579"
+zenodo_doi: "10.5281/zenodo.17347968"
+license: "CC BY-NC 4.0"
+n_participants: 95
+n_time_points: 70
+n_days: "7"
+topics: "well-being, affect, depression, affect dynamics"
+sampling_scheme: "10x/day stratified random interval"
+participants: "undergraduate students"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347968">10.5281/zenodo.17347968</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0031_koval")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0031_koval")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Koval
-- **Year:** 2013
-- **Paper DOI:** [http://doi.org/10.1037/a0033579](http://doi.org/10.1037/a0033579)
-- **Topics:** well-being, affect, depression, affect dynamics
-
-## Data Characteristics
-
-- **Participants:** 95 (undergraduate students)
-- **Time Points:** 70
-- **Days:** 7
-- **Beeps per Day:** 10
-- **Sampling Scheme:** 10x/day stratified random interval
-- **Raw Timestamp:** no
-- **Implicit Missingness:** no
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Koval</li>
+<li><strong>Year:</strong> 2013</li>
+<li><strong>Paper DOI:</strong> <a href="http://doi.org/10.1037/a0033579">http://doi.org/10.1037/a0033579</a></li>
+<li><strong>Topics:</strong> well-being, affect, depression, affect dynamics</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 95 (undergraduate students)</li>
+<li><strong>Time Points:</strong> 70</li>
+<li><strong>Days:</strong> 7</li>
+<li><strong>Beeps per Day:</strong> 10</li>
+<li><strong>Sampling Scheme:</strong> 10x/day stratified random interval</li>
+<li><strong>Raw Timestamp:</strong> no</li>
+<li><strong>Implicit Missingness:</strong> no</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/zm6uw](https://osf.io/zm6uw)
-- **Link to Codebook:** [-](-)
-- **Link to Code:** [https://osf.io/x4rne](https://osf.io/x4rne)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347968](https://doi.org/10.5281/zenodo.17347968)
-- **R:** `openesm::get_dataset("0031_koval")`
-- **Python:** `openesm.get_dataset("0031_koval")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347968">10.5281/zenodo.17347968</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/zm6uw">https://osf.io/zm6uw</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="-">-</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/x4rne">https://osf.io/x4rne</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0032_grommisch.md
+++ b/website/content/datasets/0032_grommisch.md
@@ -1,41 +1,66 @@
 ---
 title: "Grommisch (2020)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0032_grommisch"
+first_author: "Grommisch"
+year: 2020
+paper_doi: "https://doi.org/10.1037/emo0000669"
+zenodo_doi: "10.5281/zenodo.17347621"
+license: "CC BY-NC 4.0"
+n_participants: 179
+n_time_points: 189
+n_days: "21"
+topics: "emotion regulation, rumination, well-being"
+sampling_scheme: "9x/day semi-fixed intervals"
+participants: "adults"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347621">10.5281/zenodo.17347621</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0032_grommisch")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0032_grommisch")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Grommisch
-- **Year:** 2020
-- **Paper DOI:** [https://doi.org/10.1037/emo0000669](https://doi.org/10.1037/emo0000669)
-- **Topics:** emotion regulation, rumination, well-being
-
-## Data Characteristics
-
-- **Participants:** 179 (adults)
-- **Time Points:** 189
-- **Days:** 21
-- **Beeps per Day:** 9
-- **Sampling Scheme:** 9x/day semi-fixed intervals
-- **Raw Timestamp:** no
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Grommisch</li>
+<li><strong>Year:</strong> 2020</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1037/emo0000669">https://doi.org/10.1037/emo0000669</a></li>
+<li><strong>Topics:</strong> emotion regulation, rumination, well-being</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 179 (adults)</li>
+<li><strong>Time Points:</strong> 189</li>
+<li><strong>Days:</strong> 21</li>
+<li><strong>Beeps per Day:</strong> 9</li>
+<li><strong>Sampling Scheme:</strong> 9x/day semi-fixed intervals</li>
+<li><strong>Raw Timestamp:</strong> no</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/r7jw6/](https://osf.io/r7jw6/)
-- **Link to Codebook:** [https://osf.io/b5s97](https://osf.io/b5s97)
-- **Link to Code:** [https://osf.io/r7jw6/](https://osf.io/r7jw6/)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347621](https://doi.org/10.5281/zenodo.17347621)
-- **R:** `openesm::get_dataset("0032_grommisch")`
-- **Python:** `openesm.get_dataset("0032_grommisch")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347621">10.5281/zenodo.17347621</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/r7jw6/">https://osf.io/r7jw6/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/b5s97">https://osf.io/b5s97</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/r7jw6/">https://osf.io/r7jw6/</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0033_fisher.md
+++ b/website/content/datasets/0033_fisher.md
@@ -1,41 +1,66 @@
 ---
 title: "Fisher (2017)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0033_fisher"
+first_author: "Fisher"
+year: 2017
+paper_doi: "https://doi.org/10.1037/abn0000311"
+zenodo_doi: "10.5281/zenodo.17348038"
+license: "CC BY-NC 4.0"
+n_participants: 40
+n_time_points: 212
+n_days: "55"
+topics: "mood, anxiety, procrastination, depression"
+sampling_scheme: "4x/day fixed schedule"
+participants: "participants with a diagnosis of MDD and/or GAD"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17348038">10.5281/zenodo.17348038</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0033_fisher")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0033_fisher")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Fisher
-- **Year:** 2017
-- **Paper DOI:** [https://doi.org/10.1037/abn0000311](https://doi.org/10.1037/abn0000311)
-- **Topics:** mood, anxiety, procrastination, depression
-
-## Data Characteristics
-
-- **Participants:** 40 (participants with a diagnosis of MDD and/or GAD)
-- **Time Points:** 212
-- **Days:** 55
-- **Beeps per Day:** 4
-- **Sampling Scheme:** 4x/day fixed schedule
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** unclear
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Fisher</li>
+<li><strong>Year:</strong> 2017</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1037/abn0000311">https://doi.org/10.1037/abn0000311</a></li>
+<li><strong>Topics:</strong> mood, anxiety, procrastination, depression</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 40 (participants with a diagnosis of MDD and/or GAD)</li>
+<li><strong>Time Points:</strong> 212</li>
+<li><strong>Days:</strong> 55</li>
+<li><strong>Beeps per Day:</strong> 4</li>
+<li><strong>Sampling Scheme:</strong> 4x/day fixed schedule</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> unclear</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** no
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/5ybxt/](https://osf.io/5ybxt/)
-- **Link to Codebook:** [https://osf.io/h93f4](https://osf.io/h93f4)
-- **Link to Code:** [https://osf.io/m63ks](https://osf.io/m63ks)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17348038](https://doi.org/10.5281/zenodo.17348038)
-- **R:** `openesm::get_dataset("0033_fisher")`
-- **Python:** `openesm.get_dataset("0033_fisher")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17348038">10.5281/zenodo.17348038</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/5ybxt/">https://osf.io/5ybxt/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/h93f4">https://osf.io/h93f4</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/m63ks">https://osf.io/m63ks</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0034_reeves.md
+++ b/website/content/datasets/0034_reeves.md
@@ -1,41 +1,66 @@
 ---
 title: "Reeves (2020)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0034_reeves"
+first_author: "Reeves"
+year: 2020
+paper_doi: "https://doi.org/10.1002/jts.22491"
+zenodo_doi: "10.5281/zenodo.17348019"
+license: "CC BY-NC 4.0"
+n_participants: 20
+n_time_points: 168
+n_days: "43"
+topics: "PTSD, emotions, sleep, physical symptoms"
+sampling_scheme: "4x/day fixed schedule"
+participants: "participants with PTSD"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17348019">10.5281/zenodo.17348019</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0034_reeves")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0034_reeves")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Reeves
-- **Year:** 2020
-- **Paper DOI:** [https://doi.org/10.1002/jts.22491](https://doi.org/10.1002/jts.22491)
-- **Topics:** PTSD, emotions, sleep, physical symptoms
-
-## Data Characteristics
-
-- **Participants:** 20 (participants with PTSD)
-- **Time Points:** 168
-- **Days:** 43
-- **Beeps per Day:** 4
-- **Sampling Scheme:** 4x/day fixed schedule
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** unclear
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Reeves</li>
+<li><strong>Year:</strong> 2020</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1002/jts.22491">https://doi.org/10.1002/jts.22491</a></li>
+<li><strong>Topics:</strong> PTSD, emotions, sleep, physical symptoms</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 20 (participants with PTSD)</li>
+<li><strong>Time Points:</strong> 168</li>
+<li><strong>Days:</strong> 43</li>
+<li><strong>Beeps per Day:</strong> 4</li>
+<li><strong>Sampling Scheme:</strong> 4x/day fixed schedule</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> unclear</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** no
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/6vxhf/](https://osf.io/6vxhf/)
-- **Link to Codebook:** [https://osf.io/juksb](https://osf.io/juksb)
-- **Link to Code:** [https://osf.io/gv37j](https://osf.io/gv37j)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17348019](https://doi.org/10.5281/zenodo.17348019)
-- **R:** `openesm::get_dataset("0034_reeves")`
-- **Python:** `openesm.get_dataset("0034_reeves")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17348019">10.5281/zenodo.17348019</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/6vxhf/">https://osf.io/6vxhf/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/juksb">https://osf.io/juksb</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/gv37j">https://osf.io/gv37j</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0035_soyster.md
+++ b/website/content/datasets/0035_soyster.md
@@ -1,41 +1,66 @@
 ---
 title: "Soyster (2022)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0035_soyster"
+first_author: "Soyster"
+year: 2022
+paper_doi: "https://doi.org/10.1037/adb0000666"
+zenodo_doi: "10.5281/zenodo.17347645"
+license: "CC BY-NC 4.0"
+n_participants: 33
+n_time_points: 129
+n_days: "15"
+topics: "alcohol consumption, craving, affect, context"
+sampling_scheme: "8x/day semi-random schedule"
+participants: "adult alcohol consumers"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347645">10.5281/zenodo.17347645</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0035_soyster")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0035_soyster")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Soyster
-- **Year:** 2022
-- **Paper DOI:** [https://doi.org/10.1037/adb0000666](https://doi.org/10.1037/adb0000666)
-- **Topics:** alcohol consumption, craving, affect, context
-
-## Data Characteristics
-
-- **Participants:** 33 (adult alcohol consumers)
-- **Time Points:** 129
-- **Days:** 15
-- **Beeps per Day:** 8
-- **Sampling Scheme:** 8x/day semi-random schedule
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** unclear
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Soyster</li>
+<li><strong>Year:</strong> 2022</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1037/adb0000666">https://doi.org/10.1037/adb0000666</a></li>
+<li><strong>Topics:</strong> alcohol consumption, craving, affect, context</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 33 (adult alcohol consumers)</li>
+<li><strong>Time Points:</strong> 129</li>
+<li><strong>Days:</strong> 15</li>
+<li><strong>Beeps per Day:</strong> 8</li>
+<li><strong>Sampling Scheme:</strong> 8x/day semi-random schedule</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> unclear</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** no
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/q7upd/](https://osf.io/q7upd/)
-- **Link to Codebook:** [-](-)
-- **Link to Code:** [https://osf.io/bwkjq](https://osf.io/bwkjq)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347645](https://doi.org/10.5281/zenodo.17347645)
-- **R:** `openesm::get_dataset("0035_soyster")`
-- **Python:** `openesm.get_dataset("0035_soyster")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347645">10.5281/zenodo.17347645</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/q7upd/">https://osf.io/q7upd/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="-">-</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/bwkjq">https://osf.io/bwkjq</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0036_bosley.md
+++ b/website/content/datasets/0036_bosley.md
@@ -1,41 +1,66 @@
 ---
 title: "Bosley (2019)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0036_bosley"
+first_author: "Bosley"
+year: 2019
+paper_doi: "https://doi.org/10.31234/osf.io/bhn7y"
+zenodo_doi: "10.5281/zenodo.17348118"
+license: "CC BY-NC 4.0"
+n_participants: 96
+n_time_points: 45
+n_days: "19"
+topics: "GAD, affect, dampening"
+sampling_scheme: "4x/day 30-minute interval"
+participants: "undergraduate students with elevated GAD symptoms"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17348118">10.5281/zenodo.17348118</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0036_bosley")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0036_bosley")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Bosley
-- **Year:** 2019
-- **Paper DOI:** [https://doi.org/10.31234/osf.io/bhn7y](https://doi.org/10.31234/osf.io/bhn7y)
-- **Topics:** GAD, affect, dampening
-
-## Data Characteristics
-
-- **Participants:** 96 (undergraduate students with elevated GAD symptoms)
-- **Time Points:** 45
-- **Days:** 19
-- **Beeps per Day:** 4
-- **Sampling Scheme:** 4x/day 30-minute interval
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Bosley</li>
+<li><strong>Year:</strong> 2019</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.31234/osf.io/bhn7y">https://doi.org/10.31234/osf.io/bhn7y</a></li>
+<li><strong>Topics:</strong> GAD, affect, dampening</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 96 (undergraduate students with elevated GAD symptoms)</li>
+<li><strong>Time Points:</strong> 45</li>
+<li><strong>Days:</strong> 19</li>
+<li><strong>Beeps per Day:</strong> 4</li>
+<li><strong>Sampling Scheme:</strong> 4x/day 30-minute interval</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** no
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/4x8jd/](https://osf.io/4x8jd/)
-- **Link to Codebook:** [-](-)
-- **Link to Code:** [https://osf.io/8t46j](https://osf.io/8t46j)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17348118](https://doi.org/10.5281/zenodo.17348118)
-- **R:** `openesm::get_dataset("0036_bosley")`
-- **Python:** `openesm.get_dataset("0036_bosley")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17348118">10.5281/zenodo.17348118</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/4x8jd/">https://osf.io/4x8jd/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="-">-</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/8t46j">https://osf.io/8t46j</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0037_fisher.md
+++ b/website/content/datasets/0037_fisher.md
@@ -1,41 +1,66 @@
 ---
 title: "Fisher (2019)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0037_fisher"
+first_author: "Fisher"
+year: 2019
+paper_doi: "https://doi.org/10.31234/osf.io/e24v6"
+zenodo_doi: "10.5281/zenodo.17348069"
+license: "CC BY-NC 4.0"
+n_participants: 70
+n_time_points: 128
+n_days: "34"
+topics: "Smoking, affect, substance abuse"
+sampling_scheme: "4x/day random schedule"
+participants: "regular smokers"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17348069">10.5281/zenodo.17348069</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0037_fisher")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0037_fisher")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Fisher
-- **Year:** 2019
-- **Paper DOI:** [https://doi.org/10.31234/osf.io/e24v6](https://doi.org/10.31234/osf.io/e24v6)
-- **Topics:** Smoking, affect, substance abuse
-
-## Data Characteristics
-
-- **Participants:** 70 (regular smokers)
-- **Time Points:** 128
-- **Days:** 34
-- **Beeps per Day:** 4
-- **Sampling Scheme:** 4x/day random schedule
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** unclear
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Fisher</li>
+<li><strong>Year:</strong> 2019</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.31234/osf.io/e24v6">https://doi.org/10.31234/osf.io/e24v6</a></li>
+<li><strong>Topics:</strong> Smoking, affect, substance abuse</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 70 (regular smokers)</li>
+<li><strong>Time Points:</strong> 128</li>
+<li><strong>Days:</strong> 34</li>
+<li><strong>Beeps per Day:</strong> 4</li>
+<li><strong>Sampling Scheme:</strong> 4x/day random schedule</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> unclear</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** no
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/nkemg/](https://osf.io/nkemg/)
-- **Link to Codebook:** [https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0217150#sec004](https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0217150#sec004)
-- **Link to Code:** [https://osf.io/nkemg/](https://osf.io/nkemg/)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17348069](https://doi.org/10.5281/zenodo.17348069)
-- **R:** `openesm::get_dataset("0037_fisher")`
-- **Python:** `openesm.get_dataset("0037_fisher")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17348069">10.5281/zenodo.17348069</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/nkemg/">https://osf.io/nkemg/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0217150#sec004">https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0217150#sec004</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/nkemg/">https://osf.io/nkemg/</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0039_kuczynski.md
+++ b/website/content/datasets/0039_kuczynski.md
@@ -1,41 +1,66 @@
 ---
 title: "Kuczynski (2021)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0039_kuczynski"
+first_author: "Kuczynski"
+year: 2021
+paper_doi: "https://doi.org/10.1177/02654075211045717"
+zenodo_doi: "10.5281/zenodo.17347657"
+license: "CC BY-NC 4.0"
+n_participants: 515
+n_time_points: 75
+n_days: "75"
+topics: "loneliness, depression, affect, social interaction"
+sampling_scheme: "1x/day in the evening"
+participants: "adults"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347657">10.5281/zenodo.17347657</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0039_kuczynski")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0039_kuczynski")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Kuczynski
-- **Year:** 2021
-- **Paper DOI:** [https://doi.org/10.1177/02654075211045717](https://doi.org/10.1177/02654075211045717)
-- **Topics:** loneliness, depression, affect, social interaction
-
-## Data Characteristics
-
-- **Participants:** 515 (adults)
-- **Time Points:** 75
-- **Days:** 75
-- **Beeps per Day:** 1
-- **Sampling Scheme:** 1x/day in the evening
-- **Raw Timestamp:** no
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Kuczynski</li>
+<li><strong>Year:</strong> 2021</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1177/02654075211045717">https://doi.org/10.1177/02654075211045717</a></li>
+<li><strong>Topics:</strong> loneliness, depression, affect, social interaction</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 515 (adults)</li>
+<li><strong>Time Points:</strong> 75</li>
+<li><strong>Days:</strong> 75</li>
+<li><strong>Beeps per Day:</strong> 1</li>
+<li><strong>Sampling Scheme:</strong> 1x/day in the evening</li>
+<li><strong>Raw Timestamp:</strong> no</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/huz67](https://osf.io/huz67)
-- **Link to Codebook:** [-](-)
-- **Link to Code:** [https://osf.io/wtbx8/](https://osf.io/wtbx8/)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347657](https://doi.org/10.5281/zenodo.17347657)
-- **R:** `openesm::get_dataset("0039_kuczynski")`
-- **Python:** `openesm.get_dataset("0039_kuczynski")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347657">10.5281/zenodo.17347657</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/huz67">https://osf.io/huz67</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="-">-</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/wtbx8/">https://osf.io/wtbx8/</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0040_nepal.md
+++ b/website/content/datasets/0040_nepal.md
@@ -1,41 +1,66 @@
 ---
 title: "Nepal (2024)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0040_nepal"
+first_author: "Nepal"
+year: 2024
+paper_doi: "https://doi.org/10.1145/3643501"
+zenodo_doi: "10.5281/zenodo.17348144"
+license: "CC BY-NC-SA 4.0"
+n_participants: 218
+n_time_points: 441
+n_days: "441"
+topics: "mental health, resilience, behavior, COVID, anxiety, depression, social media"
+sampling_scheme: "irregular"
+participants: "undergraduate students"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17348144">10.5281/zenodo.17348144</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0040_nepal")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0040_nepal")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Nepal
-- **Year:** 2024
-- **Paper DOI:** [https://doi.org/10.1145/3643501](https://doi.org/10.1145/3643501)
-- **Topics:** mental health, resilience, behavior, COVID, anxiety, depression, social media
-
-## Data Characteristics
-
-- **Participants:** 218 (undergraduate students)
-- **Time Points:** 441
-- **Days:** 441
-- **Beeps per Day:** 1
-- **Sampling Scheme:** irregular
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** unclear
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Nepal</li>
+<li><strong>Year:</strong> 2024</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1145/3643501">https://doi.org/10.1145/3643501</a></li>
+<li><strong>Topics:</strong> mental health, resilience, behavior, COVID, anxiety, depression, social media</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 218 (undergraduate students)</li>
+<li><strong>Time Points:</strong> 441</li>
+<li><strong>Days:</strong> 441</li>
+<li><strong>Beeps per Day:</strong> 1</li>
+<li><strong>Sampling Scheme:</strong> irregular</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> unclear</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** yes
-- **Link to Original Data:** [https://www.kaggle.com/datasets/subigyanepal/college-experience-dataset](https://www.kaggle.com/datasets/subigyanepal/college-experience-dataset)
-- **Link to Codebook:** [https://www.kaggle.com/datasets/subigyanepal/college-experience-dataset/data](https://www.kaggle.com/datasets/subigyanepal/college-experience-dataset/data)
-- **Link to Code:** [null](null)
 - **License:** CC BY-NC-SA 4.0
 
-## Data Access
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17348144">10.5281/zenodo.17348144</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://www.kaggle.com/datasets/subigyanepal/college-experience-dataset">https://www.kaggle.com/datasets/subigyanepal/college-experience-dataset</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://www.kaggle.com/datasets/subigyanepal/college-experience-dataset/data">https://www.kaggle.com/datasets/subigyanepal/college-experience-dataset/data</a></p>
 
-- **Zenodo DOI:** [10.5281/zenodo.17348144](https://doi.org/10.5281/zenodo.17348144)
-- **R:** `openesm::get_dataset("0040_nepal")`
-- **Python:** `openesm.get_dataset("0040_nepal")`
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0041_wright.md
+++ b/website/content/datasets/0041_wright.md
@@ -1,41 +1,66 @@
 ---
 title: "Wright (2019)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0041_wright"
+first_author: "Wright"
+year: 2019
+paper_doi: "https://doi.org/10.1037/pas0000617"
+zenodo_doi: "10.5281/zenodo.17348148"
+license: "CC BY-NC 4.0"
+n_participants: 94
+n_time_points: 100
+n_days: "100"
+topics: "personality disorder, interpersonal behavior, stress, affect, functioning"
+sampling_scheme: "1x/day in the evening"
+participants: "individuals with personality disorder diagnosis"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17348148">10.5281/zenodo.17348148</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0041_wright")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0041_wright")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Wright
-- **Year:** 2019
-- **Paper DOI:** [https://doi.org/10.1037/pas0000617](https://doi.org/10.1037/pas0000617)
-- **Topics:** personality disorder, interpersonal behavior, stress, affect, functioning
-
-## Data Characteristics
-
-- **Participants:** 94 (individuals with personality disorder diagnosis)
-- **Time Points:** 100
-- **Days:** 100
-- **Beeps per Day:** 1
-- **Sampling Scheme:** 1x/day in the evening
-- **Raw Timestamp:** no
-- **Implicit Missingness:** unclear
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Wright</li>
+<li><strong>Year:</strong> 2019</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1037/pas0000617">https://doi.org/10.1037/pas0000617</a></li>
+<li><strong>Topics:</strong> personality disorder, interpersonal behavior, stress, affect, functioning</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 94 (individuals with personality disorder diagnosis)</li>
+<li><strong>Time Points:</strong> 100</li>
+<li><strong>Days:</strong> 100</li>
+<li><strong>Beeps per Day:</strong> 1</li>
+<li><strong>Sampling Scheme:</strong> 1x/day in the evening</li>
+<li><strong>Raw Timestamp:</strong> no</li>
+<li><strong>Implicit Missingness:</strong> unclear</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** no
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/5x8rv](https://osf.io/5x8rv)
-- **Link to Codebook:** [-](-)
-- **Link to Code:** [-](-)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17348148](https://doi.org/10.5281/zenodo.17348148)
-- **R:** `openesm::get_dataset("0041_wright")`
-- **Python:** `openesm.get_dataset("0041_wright")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17348148">10.5281/zenodo.17348148</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/5x8rv">https://osf.io/5x8rv</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="-">-</a></p>
+<p><strong>Code:</strong> <a href="-">-</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0042_mostajabi.md
+++ b/website/content/datasets/0042_mostajabi.md
@@ -1,41 +1,66 @@
 ---
 title: "Mostajabi (2024)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0042_mostajabi"
+first_author: "Mostajabi"
+year: 2024
+paper_doi: "https://doi.org/10.31219/osf.io/3szng"
+zenodo_doi: "10.5281/zenodo.17347765"
+license: "CC BY-NC 4.0"
+n_participants: 342
+n_time_points: 70
+n_days: "10"
+topics: "personality, affect, personality disorder, interpersonal"
+sampling_scheme: "random momentary prompts and scheduled daily diary"
+participants: "community participants (excluding undergraduates)"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347765">10.5281/zenodo.17347765</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0042_mostajabi")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0042_mostajabi")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Mostajabi
-- **Year:** 2024
-- **Paper DOI:** [https://doi.org/10.31219/osf.io/3szng](https://doi.org/10.31219/osf.io/3szng)
-- **Topics:** personality, affect, personality disorder, interpersonal
-
-## Data Characteristics
-
-- **Participants:** 342 (community participants (excluding undergraduates))
-- **Time Points:** 70
-- **Days:** 10
-- **Beeps per Day:** 7
-- **Sampling Scheme:** random momentary prompts and scheduled daily diary
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Mostajabi</li>
+<li><strong>Year:</strong> 2024</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.31219/osf.io/3szng">https://doi.org/10.31219/osf.io/3szng</a></li>
+<li><strong>Topics:</strong> personality, affect, personality disorder, interpersonal</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 342 (community participants (excluding undergraduates))</li>
+<li><strong>Time Points:</strong> 70</li>
+<li><strong>Days:</strong> 10</li>
+<li><strong>Beeps per Day:</strong> 7</li>
+<li><strong>Sampling Scheme:</strong> random momentary prompts and scheduled daily diary</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/dcfb5/](https://osf.io/dcfb5/)
-- **Link to Codebook:** [https://osf.io/dcfb5/files/agmcx](https://osf.io/dcfb5/files/agmcx)
-- **Link to Code:** [https://osf.io/dcfb5](https://osf.io/dcfb5)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347765](https://doi.org/10.5281/zenodo.17347765)
-- **R:** `openesm::get_dataset("0042_mostajabi")`
-- **Python:** `openesm.get_dataset("0042_mostajabi")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347765">10.5281/zenodo.17347765</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/dcfb5/">https://osf.io/dcfb5/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/dcfb5/files/agmcx">https://osf.io/dcfb5/files/agmcx</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/dcfb5">https://osf.io/dcfb5</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0043_mostajabi.md
+++ b/website/content/datasets/0043_mostajabi.md
@@ -1,41 +1,66 @@
 ---
 title: "Mostajabi (2024)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0043_mostajabi"
+first_author: "Mostajabi"
+year: 2024
+paper_doi: "https://doi.org/10.31219/osf.io/3szng"
+zenodo_doi: "10.5281/zenodo.17348182"
+license: "CC BY-NC 4.0"
+n_participants: 330
+n_time_points: 50
+n_days: "10"
+topics: "personality, affect, personality disorder, interpersonal"
+sampling_scheme: "random momentary prompts and scheduled daily diary"
+participants: "college students"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17348182">10.5281/zenodo.17348182</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0043_mostajabi")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0043_mostajabi")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Mostajabi
-- **Year:** 2024
-- **Paper DOI:** [https://doi.org/10.31219/osf.io/3szng](https://doi.org/10.31219/osf.io/3szng)
-- **Topics:** personality, affect, personality disorder, interpersonal
-
-## Data Characteristics
-
-- **Participants:** 330 (college students)
-- **Time Points:** 50
-- **Days:** 10
-- **Beeps per Day:** 5
-- **Sampling Scheme:** random momentary prompts and scheduled daily diary
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Mostajabi</li>
+<li><strong>Year:</strong> 2024</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.31219/osf.io/3szng">https://doi.org/10.31219/osf.io/3szng</a></li>
+<li><strong>Topics:</strong> personality, affect, personality disorder, interpersonal</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 330 (college students)</li>
+<li><strong>Time Points:</strong> 50</li>
+<li><strong>Days:</strong> 10</li>
+<li><strong>Beeps per Day:</strong> 5</li>
+<li><strong>Sampling Scheme:</strong> random momentary prompts and scheduled daily diary</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/dcfb5](https://osf.io/dcfb5)
-- **Link to Codebook:** [https://osf.io/dcfb5/files/agmcx](https://osf.io/dcfb5/files/agmcx)
-- **Link to Code:** [https://osf.io/dcfb5](https://osf.io/dcfb5)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17348182](https://doi.org/10.5281/zenodo.17348182)
-- **R:** `openesm::get_dataset("0043_mostajabi")`
-- **Python:** `openesm.get_dataset("0043_mostajabi")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17348182">10.5281/zenodo.17348182</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/dcfb5">https://osf.io/dcfb5</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/dcfb5/files/agmcx">https://osf.io/dcfb5/files/agmcx</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/dcfb5">https://osf.io/dcfb5</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0044_mostajabi.md
+++ b/website/content/datasets/0044_mostajabi.md
@@ -1,41 +1,66 @@
 ---
 title: "Mostajabi (2024)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0044_mostajabi"
+first_author: "Mostajabi"
+year: 2024
+paper_doi: "https://doi.org/10.31219/osf.io/3szng"
+zenodo_doi: "10.5281/zenodo.17386028"
+license: "CC BY-NC 4.0"
+n_participants: 396
+n_time_points: 42
+n_days: "7"
+topics: "personality, affect, personality disorder, interpersonal"
+sampling_scheme: "unclear"
+participants: "college students"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17386028">10.5281/zenodo.17386028</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0044_mostajabi")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0044_mostajabi")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Mostajabi
-- **Year:** 2024
-- **Paper DOI:** [https://doi.org/10.31219/osf.io/3szng](https://doi.org/10.31219/osf.io/3szng)
-- **Topics:** personality, affect, personality disorder, interpersonal
-
-## Data Characteristics
-
-- **Participants:** 396 (college students)
-- **Time Points:** 42
-- **Days:** 7
-- **Beeps per Day:** 6
-- **Sampling Scheme:** unclear
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Mostajabi</li>
+<li><strong>Year:</strong> 2024</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.31219/osf.io/3szng">https://doi.org/10.31219/osf.io/3szng</a></li>
+<li><strong>Topics:</strong> personality, affect, personality disorder, interpersonal</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 396 (college students)</li>
+<li><strong>Time Points:</strong> 42</li>
+<li><strong>Days:</strong> 7</li>
+<li><strong>Beeps per Day:</strong> 6</li>
+<li><strong>Sampling Scheme:</strong> unclear</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/dcfb5](https://osf.io/dcfb5)
-- **Link to Codebook:** [https://osf.io/dcfb5/files/agmcx](https://osf.io/dcfb5/files/agmcx)
-- **Link to Code:** [https://osf.io/dcfb5](https://osf.io/dcfb5)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17386028](https://doi.org/10.5281/zenodo.17386028)
-- **R:** `openesm::get_dataset("0044_mostajabi")`
-- **Python:** `openesm.get_dataset("0044_mostajabi")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17386028">10.5281/zenodo.17386028</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/dcfb5">https://osf.io/dcfb5</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/dcfb5/files/agmcx">https://osf.io/dcfb5/files/agmcx</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/dcfb5">https://osf.io/dcfb5</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0045_kullar.md
+++ b/website/content/datasets/0045_kullar.md
@@ -1,41 +1,66 @@
 ---
 title: "Kullar (2023)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0045_kullar"
+first_author: "Kullar"
+year: 2023
+paper_doi: "https://doi.org/10.1037/emo0001245"
+zenodo_doi: "10.5281/zenodo.17347798"
+license: "CC BY-NC 4.0"
+n_participants: 105
+n_time_points: 70
+n_days: "14"
+topics: "affect, affective chronometry, mood disorders, mind wandering"
+sampling_scheme: "5x/day fixed 30-minute interval"
+participants: "participants with and without mood disorders"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347798">10.5281/zenodo.17347798</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0045_kullar")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0045_kullar")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Kullar
-- **Year:** 2023
-- **Paper DOI:** [https://doi.org/10.1037/emo0001245](https://doi.org/10.1037/emo0001245)
-- **Topics:** affect, affective chronometry, mood disorders, mind wandering
-
-## Data Characteristics
-
-- **Participants:** 105 (participants with and without mood disorders)
-- **Time Points:** 70
-- **Days:** 14
-- **Beeps per Day:** 5
-- **Sampling Scheme:** 5x/day fixed 30-minute interval
-- **Raw Timestamp:** unclear
-- **Implicit Missingness:** no
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Kullar</li>
+<li><strong>Year:</strong> 2023</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1037/emo0001245">https://doi.org/10.1037/emo0001245</a></li>
+<li><strong>Topics:</strong> affect, affective chronometry, mood disorders, mind wandering</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 105 (participants with and without mood disorders)</li>
+<li><strong>Time Points:</strong> 70</li>
+<li><strong>Days:</strong> 14</li>
+<li><strong>Beeps per Day:</strong> 5</li>
+<li><strong>Sampling Scheme:</strong> 5x/day fixed 30-minute interval</li>
+<li><strong>Raw Timestamp:</strong> unclear</li>
+<li><strong>Implicit Missingness:</strong> no</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://github.com/mkullar/DataDrivenEmotionDynamics](https://github.com/mkullar/DataDrivenEmotionDynamics)
-- **Link to Codebook:** [-](-)
-- **Link to Code:** [https://github.com/mkullar/DataDrivenEmotionDynamics](https://github.com/mkullar/DataDrivenEmotionDynamics)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347798](https://doi.org/10.5281/zenodo.17347798)
-- **R:** `openesm::get_dataset("0045_kullar")`
-- **Python:** `openesm.get_dataset("0045_kullar")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347798">10.5281/zenodo.17347798</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://github.com/mkullar/DataDrivenEmotionDynamics">https://github.com/mkullar/DataDrivenEmotionDynamics</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="-">-</a></p>
+<p><strong>Code:</strong> <a href="https://github.com/mkullar/DataDrivenEmotionDynamics">https://github.com/mkullar/DataDrivenEmotionDynamics</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0046_ringwald.md
+++ b/website/content/datasets/0046_ringwald.md
@@ -1,41 +1,66 @@
 ---
 title: "Ringwald (2024)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0046_ringwald"
+first_author: "Ringwald"
+year: 2024
+paper_doi: "https://doi.org/10.31234/osf.io/g7n4a_v3"
+zenodo_doi: "10.5281/zenodo.17348284"
+license: "CC BY-NC 4.0"
+n_participants: 526
+n_time_points: 145
+n_days: "15"
+topics: "empathy, affect, interpersonal, congruence, social perception"
+sampling_scheme: "event-contingent based on social interactions"
+participants: "adults (18-50)"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17348284">10.5281/zenodo.17348284</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0046_ringwald")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0046_ringwald")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Ringwald
-- **Year:** 2024
-- **Paper DOI:** [https://doi.org/10.31234/osf.io/g7n4a_v3](https://doi.org/10.31234/osf.io/g7n4a_v3)
-- **Topics:** empathy, affect, interpersonal, congruence, social perception
-
-## Data Characteristics
-
-- **Participants:** 526 (adults (18-50))
-- **Time Points:** 145
-- **Days:** 15
-- **Beeps per Day:** event-contingent
-- **Sampling Scheme:** event-contingent based on social interactions
-- **Raw Timestamp:** no
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Ringwald</li>
+<li><strong>Year:</strong> 2024</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.31234/osf.io/g7n4a_v3">https://doi.org/10.31234/osf.io/g7n4a_v3</a></li>
+<li><strong>Topics:</strong> empathy, affect, interpersonal, congruence, social perception</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 526 (adults (18-50))</li>
+<li><strong>Time Points:</strong> 145</li>
+<li><strong>Days:</strong> 15</li>
+<li><strong>Beeps per Day:</strong> event-contingent</li>
+<li><strong>Sampling Scheme:</strong> event-contingent based on social interactions</li>
+<li><strong>Raw Timestamp:</strong> no</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** no
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/unvp8](https://osf.io/unvp8)
-- **Link to Codebook:** not available
-- **Link to Code:** [https://osf.io/unvp8](https://osf.io/unvp8)
 - **License:** CC BY-NC 4.0
 
-## Data Access
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17348284">10.5281/zenodo.17348284</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/unvp8">https://osf.io/unvp8</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
 
-- **Zenodo DOI:** [10.5281/zenodo.17348284](https://doi.org/10.5281/zenodo.17348284)
-- **R:** `openesm::get_dataset("0046_ringwald")`
-- **Python:** `openesm.get_dataset("0046_ringwald")`
+<p><strong>Code:</strong> <a href="https://osf.io/unvp8">https://osf.io/unvp8</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0049_pronizius.md
+++ b/website/content/datasets/0049_pronizius.md
@@ -1,41 +1,66 @@
 ---
 title: "Pronizius (2024)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0049_pronizius"
+first_author: "Pronizius"
+year: 2024
+paper_doi: "https://doi.org/10.1038/s41598-024-75261-z"
+zenodo_doi: "10.5281/zenodo.17348222"
+license: "CC-BY 4.0"
+n_participants: 803
+n_time_points: 35
+n_days: "7"
+topics: "helping, mood, prosocial behavior, stress, COVID"
+sampling_scheme: "4x semi-random, 1 prompt user-initiated before sleep"
+participants: "adults experiencing COVID lockdown"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17348222">10.5281/zenodo.17348222</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0049_pronizius")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0049_pronizius")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Pronizius
-- **Year:** 2024
-- **Paper DOI:** [https://doi.org/10.1038/s41598-024-75261-z](https://doi.org/10.1038/s41598-024-75261-z)
-- **Topics:** helping, mood, prosocial behavior, stress, COVID
-
-## Data Characteristics
-
-- **Participants:** 803 (adults experiencing COVID lockdown)
-- **Time Points:** 35
-- **Days:** 7
-- **Beeps per Day:** 5
-- **Sampling Scheme:** 4x semi-random, 1 prompt user-initiated before sleep
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** unclear
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Pronizius</li>
+<li><strong>Year:</strong> 2024</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1038/s41598-024-75261-z">https://doi.org/10.1038/s41598-024-75261-z</a></li>
+<li><strong>Topics:</strong> helping, mood, prosocial behavior, stress, COVID</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 803 (adults experiencing COVID lockdown)</li>
+<li><strong>Time Points:</strong> 35</li>
+<li><strong>Days:</strong> 7</li>
+<li><strong>Beeps per Day:</strong> 5</li>
+<li><strong>Sampling Scheme:</strong> 4x semi-random, 1 prompt user-initiated before sleep</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> unclear</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/6n5zj/](https://osf.io/6n5zj/)
-- **Link to Codebook:** [https://osf.io/4tpvd](https://osf.io/4tpvd)
-- **Link to Code:** [https://osf.io/6n5zj](https://osf.io/6n5zj)
 - **License:** CC-BY 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17348222](https://doi.org/10.5281/zenodo.17348222)
-- **R:** `openesm::get_dataset("0049_pronizius")`
-- **Python:** `openesm.get_dataset("0049_pronizius")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17348222">10.5281/zenodo.17348222</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/6n5zj/">https://osf.io/6n5zj/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/4tpvd">https://osf.io/4tpvd</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/6n5zj">https://osf.io/6n5zj</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0050_pronizius.md
+++ b/website/content/datasets/0050_pronizius.md
@@ -1,41 +1,66 @@
 ---
 title: "Pronizius (2024)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0050_pronizius"
+first_author: "Pronizius"
+year: 2024
+paper_doi: "https://doi.org/10.1038/s41598-024-75261-z"
+zenodo_doi: "10.5281/zenodo.17347819"
+license: "CC-BY 4.0"
+n_participants: 303
+n_time_points: 35
+n_days: "7"
+topics: "helping, mood, prosocial behavior, stress, COVID"
+sampling_scheme: "4x semi-random, 1 prompt user-initiated before sleep"
+participants: "adults experiencing COVID lockdown"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347819">10.5281/zenodo.17347819</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0050_pronizius")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0050_pronizius")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Pronizius
-- **Year:** 2024
-- **Paper DOI:** [https://doi.org/10.1038/s41598-024-75261-z](https://doi.org/10.1038/s41598-024-75261-z)
-- **Topics:** helping, mood, prosocial behavior, stress, COVID
-
-## Data Characteristics
-
-- **Participants:** 303 (adults experiencing COVID lockdown)
-- **Time Points:** 35
-- **Days:** 7
-- **Beeps per Day:** 5
-- **Sampling Scheme:** 4x semi-random, 1 prompt user-initiated before sleep
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** unclear
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Pronizius</li>
+<li><strong>Year:</strong> 2024</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1038/s41598-024-75261-z">https://doi.org/10.1038/s41598-024-75261-z</a></li>
+<li><strong>Topics:</strong> helping, mood, prosocial behavior, stress, COVID</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 303 (adults experiencing COVID lockdown)</li>
+<li><strong>Time Points:</strong> 35</li>
+<li><strong>Days:</strong> 7</li>
+<li><strong>Beeps per Day:</strong> 5</li>
+<li><strong>Sampling Scheme:</strong> 4x semi-random, 1 prompt user-initiated before sleep</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> unclear</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/6n5zj/](https://osf.io/6n5zj/)
-- **Link to Codebook:** [https://osf.io/4tpvd](https://osf.io/4tpvd)
-- **Link to Code:** [https://osf.io/6n5zj](https://osf.io/6n5zj)
 - **License:** CC-BY 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347819](https://doi.org/10.5281/zenodo.17347819)
-- **R:** `openesm::get_dataset("0050_pronizius")`
-- **Python:** `openesm.get_dataset("0050_pronizius")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347819">10.5281/zenodo.17347819</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/6n5zj/">https://osf.io/6n5zj/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/4tpvd">https://osf.io/4tpvd</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/6n5zj">https://osf.io/6n5zj</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0051_johannes.md
+++ b/website/content/datasets/0051_johannes.md
@@ -1,41 +1,66 @@
 ---
 title: "Johannes (2021)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0051_johannes"
+first_author: "Johannes"
+year: 2021
+paper_doi: "https://doi.org/10.1080/15213269.2020.1768122"
+zenodo_doi: "10.5281/zenodo.17348348"
+license: "CC-BY 4.0"
+n_participants: 75
+n_time_points: 40
+n_days: "5"
+topics: "online vigilance, affect, wellbeing, smartphone, social interactions"
+sampling_scheme: "8x semi-random with at least 45 minutes between surveys"
+participants: "Dutch undergraduate students using social media"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17348348">10.5281/zenodo.17348348</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0051_johannes")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0051_johannes")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Johannes
-- **Year:** 2021
-- **Paper DOI:** [https://doi.org/10.1080/15213269.2020.1768122](https://doi.org/10.1080/15213269.2020.1768122)
-- **Topics:** online vigilance, affect, wellbeing, smartphone, social interactions
-
-## Data Characteristics
-
-- **Participants:** 75 (Dutch undergraduate students using social media)
-- **Time Points:** 40
-- **Days:** 5
-- **Beeps per Day:** 8
-- **Sampling Scheme:** 8x semi-random with at least 45 minutes between surveys
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** no
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Johannes</li>
+<li><strong>Year:</strong> 2021</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1080/15213269.2020.1768122">https://doi.org/10.1080/15213269.2020.1768122</a></li>
+<li><strong>Topics:</strong> online vigilance, affect, wellbeing, smartphone, social interactions</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 75 (Dutch undergraduate students using social media)</li>
+<li><strong>Time Points:</strong> 40</li>
+<li><strong>Days:</strong> 5</li>
+<li><strong>Beeps per Day:</strong> 8</li>
+<li><strong>Sampling Scheme:</strong> 8x semi-random with at least 45 minutes between surveys</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> no</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** yes
-- **Link to Original Data:** [https://osf.io/ps3rk/files](https://osf.io/ps3rk/files)
-- **Link to Codebook:** [https://osf.io/xf2pq/](https://osf.io/xf2pq/)
-- **Link to Code:** [https://osf.io/ps3rk/files](https://osf.io/ps3rk/files)
 - **License:** CC-BY 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17348348](https://doi.org/10.5281/zenodo.17348348)
-- **R:** `openesm::get_dataset("0051_johannes")`
-- **Python:** `openesm.get_dataset("0051_johannes")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17348348">10.5281/zenodo.17348348</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/ps3rk/files">https://osf.io/ps3rk/files</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/xf2pq/">https://osf.io/xf2pq/</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/ps3rk/files">https://osf.io/ps3rk/files</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0052_marian.md
+++ b/website/content/datasets/0052_marian.md
@@ -1,41 +1,66 @@
 ---
 title: "Marian (2022)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0052_marian"
+first_author: "Marian"
+year: 2022
+paper_doi: "https://doi.org/10.1007/s10862-022-10014-8"
+zenodo_doi: "10.5281/zenodo.17348267"
+license: "CC-BY 4.0"
+n_participants: 140
+n_time_points: 63
+n_days: "21"
+topics: "depression, anxiety, COVID"
+sampling_scheme: "4x/day 4 hour intervals based on individual wake-up time"
+participants: "undergraduate students"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17348267">10.5281/zenodo.17348267</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0052_marian")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0052_marian")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Marian
-- **Year:** 2022
-- **Paper DOI:** [https://doi.org/10.1007/s10862-022-10014-8](https://doi.org/10.1007/s10862-022-10014-8)
-- **Topics:** depression, anxiety, COVID
-
-## Data Characteristics
-
-- **Participants:** 140 (undergraduate students)
-- **Time Points:** 63
-- **Days:** 21
-- **Beeps per Day:** 3
-- **Sampling Scheme:** 4x/day 4 hour intervals based on individual wake-up time
-- **Raw Timestamp:** no
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Marian</li>
+<li><strong>Year:</strong> 2022</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1007/s10862-022-10014-8">https://doi.org/10.1007/s10862-022-10014-8</a></li>
+<li><strong>Topics:</strong> depression, anxiety, COVID</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 140 (undergraduate students)</li>
+<li><strong>Time Points:</strong> 63</li>
+<li><strong>Days:</strong> 21</li>
+<li><strong>Beeps per Day:</strong> 3</li>
+<li><strong>Sampling Scheme:</strong> 4x/day 4 hour intervals based on individual wake-up time</li>
+<li><strong>Raw Timestamp:</strong> no</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/pt9dk](https://osf.io/pt9dk)
-- **Link to Codebook:** [https://osf.io/r85q6](https://osf.io/r85q6)
-- **Link to Code:** [https://osf.io/pt9dk](https://osf.io/pt9dk)
 - **License:** CC-BY 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17348267](https://doi.org/10.5281/zenodo.17348267)
-- **R:** `openesm::get_dataset("0052_marian")`
-- **Python:** `openesm.get_dataset("0052_marian")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17348267">10.5281/zenodo.17348267</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/pt9dk">https://osf.io/pt9dk</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/r85q6">https://osf.io/r85q6</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/pt9dk">https://osf.io/pt9dk</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0053_stevens.md
+++ b/website/content/datasets/0053_stevens.md
@@ -1,41 +1,66 @@
 ---
 title: "Stevens (2020)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0053_stevens"
+first_author: "Stevens"
+year: 2020
+paper_doi: "https://doi.org/10.1016/j.bodyim.2020.09.003"
+zenodo_doi: "10.5281/zenodo.17347854"
+license: "CC BY-NC 4.0"
+n_participants: 133
+n_time_points: 42
+n_days: "7"
+topics: "body positivity, social media, affect, body satisfaction, fitspiration"
+sampling_scheme: "6x/day semi-random intervals with anchor times and 40 minute period around them"
+participants: "undergraduate students"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347854">10.5281/zenodo.17347854</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0053_stevens")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0053_stevens")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Stevens
-- **Year:** 2020
-- **Paper DOI:** [https://doi.org/10.1016/j.bodyim.2020.09.003](https://doi.org/10.1016/j.bodyim.2020.09.003)
-- **Topics:** body positivity, social media, affect, body satisfaction, fitspiration
-
-## Data Characteristics
-
-- **Participants:** 133 (undergraduate students)
-- **Time Points:** 42
-- **Days:** 7
-- **Beeps per Day:** 6
-- **Sampling Scheme:** 6x/day semi-random intervals with anchor times and 40 minute period around them
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** no
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Stevens</li>
+<li><strong>Year:</strong> 2020</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1016/j.bodyim.2020.09.003">https://doi.org/10.1016/j.bodyim.2020.09.003</a></li>
+<li><strong>Topics:</strong> body positivity, social media, affect, body satisfaction, fitspiration</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 133 (undergraduate students)</li>
+<li><strong>Time Points:</strong> 42</li>
+<li><strong>Days:</strong> 7</li>
+<li><strong>Beeps per Day:</strong> 6</li>
+<li><strong>Sampling Scheme:</strong> 6x/day semi-random intervals with anchor times and 40 minute period around them</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> no</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/qy9uj/files/](https://osf.io/qy9uj/files/)
-- **Link to Codebook:** not available
-- **Link to Code:** [https://osf.io/qy9uj/files/](https://osf.io/qy9uj/files/)
 - **License:** CC BY-NC 4.0
 
-## Data Access
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347854">10.5281/zenodo.17347854</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/qy9uj/files/">https://osf.io/qy9uj/files/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
 
-- **Zenodo DOI:** [10.5281/zenodo.17347854](https://doi.org/10.5281/zenodo.17347854)
-- **R:** `openesm::get_dataset("0053_stevens")`
-- **Python:** `openesm.get_dataset("0053_stevens")`
+<p><strong>Code:</strong> <a href="https://osf.io/qy9uj/files/">https://osf.io/qy9uj/files/</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0054_tammilehto.md
+++ b/website/content/datasets/0054_tammilehto.md
@@ -1,41 +1,66 @@
 ---
 title: "Tammilehto (2022)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0054_tammilehto"
+first_author: "Tammilehto"
+year: 2022
+paper_doi: "https://doi.org/10.1080/02699931.2022.2081534"
+zenodo_doi: "10.5281/zenodo.17361509"
+license: "CC-BY 4.0"
+n_participants: 122
+n_time_points: 49
+n_days: "7"
+topics: "emotion regulation, attachment, neuroticism"
+sampling_scheme: "7x/day semi-random intervals, scheduled in blocks"
+participants: "undergraduate students"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17361509">10.5281/zenodo.17361509</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0054_tammilehto")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0054_tammilehto")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Tammilehto
-- **Year:** 2022
-- **Paper DOI:** [https://doi.org/10.1080/02699931.2022.2081534](https://doi.org/10.1080/02699931.2022.2081534)
-- **Topics:** emotion regulation, attachment, neuroticism
-
-## Data Characteristics
-
-- **Participants:** 122 (undergraduate students)
-- **Time Points:** 49
-- **Days:** 7
-- **Beeps per Day:** 7
-- **Sampling Scheme:** 7x/day semi-random intervals, scheduled in blocks
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** no
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Tammilehto</li>
+<li><strong>Year:</strong> 2022</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1080/02699931.2022.2081534">https://doi.org/10.1080/02699931.2022.2081534</a></li>
+<li><strong>Topics:</strong> emotion regulation, attachment, neuroticism</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 122 (undergraduate students)</li>
+<li><strong>Time Points:</strong> 49</li>
+<li><strong>Days:</strong> 7</li>
+<li><strong>Beeps per Day:</strong> 7</li>
+<li><strong>Sampling Scheme:</strong> 7x/day semi-random intervals, scheduled in blocks</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> no</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/e8423](https://osf.io/e8423)
-- **Link to Codebook:** [https://osf.io/u59nd/files/](https://osf.io/u59nd/files/)
-- **Link to Code:** [https://osf.io/u59nd/files/](https://osf.io/u59nd/files/)
 - **License:** CC-BY 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17361509](https://doi.org/10.5281/zenodo.17361509)
-- **R:** `openesm::get_dataset("0054_tammilehto")`
-- **Python:** `openesm.get_dataset("0054_tammilehto")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17361509">10.5281/zenodo.17361509</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/e8423">https://osf.io/e8423</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/u59nd/files/">https://osf.io/u59nd/files/</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/u59nd/files/">https://osf.io/u59nd/files/</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0055_wang.md
+++ b/website/content/datasets/0055_wang.md
@@ -1,41 +1,66 @@
 ---
 title: "Wang (2024)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0055_wang"
+first_author: "Wang"
+year: 2024
+paper_doi: "https://doi.org/10.1111/famp.12995"
+zenodo_doi: "10.5281/zenodo.17348326"
+license: "CC BY-NC 4.0"
+n_participants: 78
+n_time_points: 147
+n_days: "21"
+topics: "family conflict, social interactions, affect, emotion, sadness"
+sampling_scheme: "6x/day EMA, 1x/day daily diary, morning survey at self-chosen time, other surveys randomly with certain interval, daily diary at 6:30pm"
+participants: "young adults (18-25)"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17348326">10.5281/zenodo.17348326</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0055_wang")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0055_wang")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Wang
-- **Year:** 2024
-- **Paper DOI:** [https://doi.org/10.1111/famp.12995](https://doi.org/10.1111/famp.12995)
-- **Topics:** family conflict, social interactions, affect, emotion, sadness
-
-## Data Characteristics
-
-- **Participants:** 78 (young adults (18-25))
-- **Time Points:** 147
-- **Days:** 21
-- **Beeps per Day:** 7
-- **Sampling Scheme:** 6x/day EMA, 1x/day daily diary, morning survey at self-chosen time, other surveys randomly with certain interval, daily diary at 6:30pm
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** no
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Wang</li>
+<li><strong>Year:</strong> 2024</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1111/famp.12995">https://doi.org/10.1111/famp.12995</a></li>
+<li><strong>Topics:</strong> family conflict, social interactions, affect, emotion, sadness</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 78 (young adults (18-25))</li>
+<li><strong>Time Points:</strong> 147</li>
+<li><strong>Days:</strong> 21</li>
+<li><strong>Beeps per Day:</strong> 7</li>
+<li><strong>Sampling Scheme:</strong> 6x/day EMA, 1x/day daily diary, morning survey at self-chosen time, other surveys randomly with certain interval, daily diary at 6:30pm</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> no</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/8jhuk](https://osf.io/8jhuk)
-- **Link to Codebook:** not available
-- **Link to Code:** [https://osf.io/8jhuk](https://osf.io/8jhuk)
 - **License:** CC BY-NC 4.0
 
-## Data Access
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17348326">10.5281/zenodo.17348326</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/8jhuk">https://osf.io/8jhuk</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
 
-- **Zenodo DOI:** [10.5281/zenodo.17348326](https://doi.org/10.5281/zenodo.17348326)
-- **R:** `openesm::get_dataset("0055_wang")`
-- **Python:** `openesm.get_dataset("0055_wang")`
+<p><strong>Code:</strong> <a href="https://osf.io/8jhuk">https://osf.io/8jhuk</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0056_ryvkina.md
+++ b/website/content/datasets/0056_ryvkina.md
@@ -1,41 +1,66 @@
 ---
 title: "Ryvkina (2023)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0056_ryvkina"
+first_author: "Ryvkina"
+year: 2023
+paper_doi: "https://doi.org/10.5334/jopd.83"
+zenodo_doi: ""
+license: "CC-BY 4.0"
+n_participants: 327
+n_time_points: 84
+n_days: "14"
+topics: "COVID, personality, emotions, affect, interaction, activities"
+sampling_scheme: "6x/day at random times within the bounds of every participant's individually preferred time window, with at least 40 min. time lags between surveys"
+participants: "mostly college students"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><em>Zenodo DOI not yet available</em></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0056_ryvkina")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0056_ryvkina")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Ryvkina
-- **Year:** 2023
-- **Paper DOI:** [https://doi.org/10.5334/jopd.83](https://doi.org/10.5334/jopd.83)
-- **Topics:** COVID, personality, emotions, affect, interaction, activities
-
-## Data Characteristics
-
-- **Participants:** 327 (mostly college students)
-- **Time Points:** 84
-- **Days:** 14
-- **Beeps per Day:** 6
-- **Sampling Scheme:** 6x/day at random times within the bounds of every participant's individually preferred time window, with at least 40 min. time lags between surveys
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Ryvkina</li>
+<li><strong>Year:</strong> 2023</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.5334/jopd.83">https://doi.org/10.5334/jopd.83</a></li>
+<li><strong>Topics:</strong> COVID, personality, emotions, affect, interaction, activities</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 327 (mostly college students)</li>
+<li><strong>Time Points:</strong> 84</li>
+<li><strong>Days:</strong> 14</li>
+<li><strong>Beeps per Day:</strong> 6</li>
+<li><strong>Sampling Scheme:</strong> 6x/day at random times within the bounds of every participant's individually preferred time window, with at least 40 min. time lags between surveys</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/6kzx3/](https://osf.io/6kzx3/)
-- **Link to Codebook:** [https://osf.io/6kzx3/](https://osf.io/6kzx3/)
-- **Link to Code:** [https://osf.io/6kzx3/](https://osf.io/6kzx3/)
 - **License:** CC-BY 4.0
 
-## Data Access
+<div class="dataset-links">
 
-- **Zenodo DOI:** not available
-- **R:** `openesm::get_dataset("0056_ryvkina")`
-- **Python:** `openesm.get_dataset("0056_ryvkina")`
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/6kzx3/">https://osf.io/6kzx3/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/6kzx3/">https://osf.io/6kzx3/</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/6kzx3/">https://osf.io/6kzx3/</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0057_ryvkina.md
+++ b/website/content/datasets/0057_ryvkina.md
@@ -1,41 +1,66 @@
 ---
 title: "Ryvkina (2023)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0057_ryvkina"
+first_author: "Ryvkina"
+year: 2023
+paper_doi: "https://doi.org/10.5334/jopd.83"
+zenodo_doi: "10.5281/zenodo.17361657"
+license: "CC-BY 4.0"
+n_participants: 2272
+n_time_points: 84
+n_days: "14"
+topics: "COVID, personality, emotions, affect, interaction, activities"
+sampling_scheme: "6x/day at random times within the bounds of every participant's individually preferred time window, with at least 40 min. time lags between surveys"
+participants: "general population"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17361657">10.5281/zenodo.17361657</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0057_ryvkina")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0057_ryvkina")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Ryvkina
-- **Year:** 2023
-- **Paper DOI:** [https://doi.org/10.5334/jopd.83](https://doi.org/10.5334/jopd.83)
-- **Topics:** COVID, personality, emotions, affect, interaction, activities
-
-## Data Characteristics
-
-- **Participants:** 2272 (general population)
-- **Time Points:** 84
-- **Days:** 14
-- **Beeps per Day:** 6
-- **Sampling Scheme:** 6x/day at random times within the bounds of every participant's individually preferred time window, with at least 40 min. time lags between surveys
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Ryvkina</li>
+<li><strong>Year:</strong> 2023</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.5334/jopd.83">https://doi.org/10.5334/jopd.83</a></li>
+<li><strong>Topics:</strong> COVID, personality, emotions, affect, interaction, activities</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 2272 (general population)</li>
+<li><strong>Time Points:</strong> 84</li>
+<li><strong>Days:</strong> 14</li>
+<li><strong>Beeps per Day:</strong> 6</li>
+<li><strong>Sampling Scheme:</strong> 6x/day at random times within the bounds of every participant's individually preferred time window, with at least 40 min. time lags between surveys</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/6kzx3/](https://osf.io/6kzx3/)
-- **Link to Codebook:** [https://osf.io/6kzx3/](https://osf.io/6kzx3/)
-- **Link to Code:** [https://osf.io/6kzx3/](https://osf.io/6kzx3/)
 - **License:** CC-BY 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17361657](https://doi.org/10.5281/zenodo.17361657)
-- **R:** `openesm::get_dataset("0057_ryvkina")`
-- **Python:** `openesm.get_dataset("0057_ryvkina")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17361657">10.5281/zenodo.17361657</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/6kzx3/">https://osf.io/6kzx3/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/6kzx3/">https://osf.io/6kzx3/</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/6kzx3/">https://osf.io/6kzx3/</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0058_gainey.md
+++ b/website/content/datasets/0058_gainey.md
@@ -1,41 +1,66 @@
 ---
 title: "Gainey (2023)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0058_gainey"
+first_author: "Gainey"
+year: 2023
+paper_doi: "https://doi.org/10.1177/21677026221147262"
+zenodo_doi: "10.5281/zenodo.17348369"
+license: "CC BY-NC 4.0"
+n_participants: 356
+n_time_points: 42
+n_days: "7"
+topics: "awareness, mindfulness, emotion, cognitive fusion, well-being"
+sampling_scheme: "6x/day pseudo-random intervals with minimum interval between prompts"
+participants: "adults, oversampled for people in treatment or seeking treatment"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17348369">10.5281/zenodo.17348369</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0058_gainey")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0058_gainey")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Gainey
-- **Year:** 2023
-- **Paper DOI:** [https://doi.org/10.1177/21677026221147262](https://doi.org/10.1177/21677026221147262)
-- **Topics:** awareness, mindfulness, emotion, cognitive fusion, well-being
-
-## Data Characteristics
-
-- **Participants:** 356 (adults, oversampled for people in treatment or seeking treatment)
-- **Time Points:** 42
-- **Days:** 7
-- **Beeps per Day:** 6
-- **Sampling Scheme:** 6x/day pseudo-random intervals with minimum interval between prompts
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** no
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Gainey</li>
+<li><strong>Year:</strong> 2023</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1177/21677026221147262">https://doi.org/10.1177/21677026221147262</a></li>
+<li><strong>Topics:</strong> awareness, mindfulness, emotion, cognitive fusion, well-being</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 356 (adults, oversampled for people in treatment or seeking treatment)</li>
+<li><strong>Time Points:</strong> 42</li>
+<li><strong>Days:</strong> 7</li>
+<li><strong>Beeps per Day:</strong> 6</li>
+<li><strong>Sampling Scheme:</strong> 6x/day pseudo-random intervals with minimum interval between prompts</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> no</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/gct7x/](https://osf.io/gct7x/)
-- **Link to Codebook:** [https://osf.io/gct7x](https://osf.io/gct7x)
-- **Link to Code:** [https://osf.io/gct7x/files/osfstorage](https://osf.io/gct7x/files/osfstorage)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17348369](https://doi.org/10.5281/zenodo.17348369)
-- **R:** `openesm::get_dataset("0058_gainey")`
-- **Python:** `openesm.get_dataset("0058_gainey")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17348369">10.5281/zenodo.17348369</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/gct7x/">https://osf.io/gct7x/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/gct7x">https://osf.io/gct7x</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/gct7x/files/osfstorage">https://osf.io/gct7x/files/osfstorage</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0059_blanke.md
+++ b/website/content/datasets/0059_blanke.md
@@ -1,41 +1,66 @@
 ---
 title: "Blanke (2020)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0059_blanke"
+first_author: "Blanke"
+year: 2020
+paper_doi: "https://doi.org/10.1037/emo0000659"
+zenodo_doi: "10.5281/zenodo.17347911"
+license: "CC BY-NC 4.0"
+n_participants: 70
+n_time_points: 54
+n_days: "9"
+topics: "mindfulness, reflection, affect, well-being, emotion regulation"
+sampling_scheme: "6x/day within self-selected 12hr timeframe"
+participants: "students"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347911">10.5281/zenodo.17347911</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0059_blanke")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0059_blanke")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Blanke
-- **Year:** 2020
-- **Paper DOI:** [https://doi.org/10.1037/emo0000659](https://doi.org/10.1037/emo0000659)
-- **Topics:** mindfulness, reflection, affect, well-being, emotion regulation
-
-## Data Characteristics
-
-- **Participants:** 70 (students)
-- **Time Points:** 54
-- **Days:** 9
-- **Beeps per Day:** 6
-- **Sampling Scheme:** 6x/day within self-selected 12hr timeframe
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** no
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Blanke</li>
+<li><strong>Year:</strong> 2020</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1037/emo0000659">https://doi.org/10.1037/emo0000659</a></li>
+<li><strong>Topics:</strong> mindfulness, reflection, affect, well-being, emotion regulation</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 70 (students)</li>
+<li><strong>Time Points:</strong> 54</li>
+<li><strong>Days:</strong> 9</li>
+<li><strong>Beeps per Day:</strong> 6</li>
+<li><strong>Sampling Scheme:</strong> 6x/day within self-selected 12hr timeframe</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> no</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** no
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/nvt6a/](https://osf.io/nvt6a/)
-- **Link to Codebook:** [https://osf.io/v2am8](https://osf.io/v2am8)
-- **Link to Code:** [null](null)
 - **License:** CC BY-NC 4.0
 
-## Data Access
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347911">10.5281/zenodo.17347911</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/nvt6a/">https://osf.io/nvt6a/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/v2am8">https://osf.io/v2am8</a></p>
 
-- **Zenodo DOI:** [10.5281/zenodo.17347911](https://doi.org/10.5281/zenodo.17347911)
-- **R:** `openesm::get_dataset("0059_blanke")`
-- **Python:** `openesm.get_dataset("0059_blanke")`
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0060_beck.md
+++ b/website/content/datasets/0060_beck.md
@@ -1,41 +1,66 @@
 ---
 title: "Beck (2022)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0060_beck"
+first_author: "Beck"
+year: 2022
+paper_doi: "https://doi.org/10.1177/09567976221093307"
+zenodo_doi: "10.5281/zenodo.17361673"
+license: "CC BY-NC 4.0"
+n_participants: 199
+n_time_points: 109
+n_days: "43"
+topics: "personality, affect, situations, procrastination, loneliness"
+sampling_scheme: "4x/day every fixed schedule every for hours, starting time chosen by participants"
+participants: "students"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17361673">10.5281/zenodo.17361673</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0060_beck")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0060_beck")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Beck
-- **Year:** 2022
-- **Paper DOI:** [https://doi.org/10.1177/09567976221093307](https://doi.org/10.1177/09567976221093307)
-- **Topics:** personality, affect, situations, procrastination, loneliness
-
-## Data Characteristics
-
-- **Participants:** 199 (students)
-- **Time Points:** 109
-- **Days:** 43
-- **Beeps per Day:** 4
-- **Sampling Scheme:** 4x/day every fixed schedule every for hours, starting time chosen by participants
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** unclear
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Beck</li>
+<li><strong>Year:</strong> 2022</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1177/09567976221093307">https://doi.org/10.1177/09567976221093307</a></li>
+<li><strong>Topics:</strong> personality, affect, situations, procrastination, loneliness</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 199 (students)</li>
+<li><strong>Time Points:</strong> 109</li>
+<li><strong>Days:</strong> 43</li>
+<li><strong>Beeps per Day:</strong> 4</li>
+<li><strong>Sampling Scheme:</strong> 4x/day every fixed schedule every for hours, starting time chosen by participants</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> unclear</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/8ebyx/](https://osf.io/8ebyx/)
-- **Link to Codebook:** [https://github.com/emoriebeck/behavior-prediction/tree/main/01-codebooks](https://github.com/emoriebeck/behavior-prediction/tree/main/01-codebooks)
-- **Link to Code:** [https://osf.io/8ebyx/](https://osf.io/8ebyx/)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17361673](https://doi.org/10.5281/zenodo.17361673)
-- **R:** `openesm::get_dataset("0060_beck")`
-- **Python:** `openesm.get_dataset("0060_beck")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17361673">10.5281/zenodo.17361673</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/8ebyx/">https://osf.io/8ebyx/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://github.com/emoriebeck/behavior-prediction/tree/main/01-codebooks">https://github.com/emoriebeck/behavior-prediction/tree/main/01-codebooks</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/8ebyx/">https://osf.io/8ebyx/</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0061_merolla.md
+++ b/website/content/datasets/0061_merolla.md
@@ -1,41 +1,66 @@
 ---
 title: "Merolla (2022)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0061_merolla"
+first_author: "Merolla"
+year: 2022
+paper_doi: "https://doi.org/10.1007/s10902-024-00710-5"
+zenodo_doi: "10.5281/zenodo.17348441"
+license: "CC BY-NC 4.0"
+n_participants: 120
+n_time_points: 60
+n_days: "10"
+topics: "responsiveness, social connection, hope, life satisfaction"
+sampling_scheme: "6x/day random schedule"
+participants: "undergraduate students"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17348441">10.5281/zenodo.17348441</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0061_merolla")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0061_merolla")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Merolla
-- **Year:** 2022
-- **Paper DOI:** [https://doi.org/10.1007/s10902-024-00710-5](https://doi.org/10.1007/s10902-024-00710-5)
-- **Topics:** responsiveness, social connection, hope, life satisfaction
-
-## Data Characteristics
-
-- **Participants:** 120 (undergraduate students)
-- **Time Points:** 60
-- **Days:** 10
-- **Beeps per Day:** 6
-- **Sampling Scheme:** 6x/day random schedule
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** no
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Merolla</li>
+<li><strong>Year:</strong> 2022</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1007/s10902-024-00710-5">https://doi.org/10.1007/s10902-024-00710-5</a></li>
+<li><strong>Topics:</strong> responsiveness, social connection, hope, life satisfaction</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 120 (undergraduate students)</li>
+<li><strong>Time Points:</strong> 60</li>
+<li><strong>Days:</strong> 10</li>
+<li><strong>Beeps per Day:</strong> 6</li>
+<li><strong>Sampling Scheme:</strong> 6x/day random schedule</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> no</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/nts94/](https://osf.io/nts94/)
-- **Link to Codebook:** not available
-- **Link to Code:** [https://osf.io/nts94](https://osf.io/nts94)
 - **License:** CC BY-NC 4.0
 
-## Data Access
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17348441">10.5281/zenodo.17348441</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/nts94/">https://osf.io/nts94/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
 
-- **Zenodo DOI:** [10.5281/zenodo.17348441](https://doi.org/10.5281/zenodo.17348441)
-- **R:** `openesm::get_dataset("0061_merolla")`
-- **Python:** `openesm.get_dataset("0061_merolla")`
+<p><strong>Code:</strong> <a href="https://osf.io/nts94">https://osf.io/nts94</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0062_neubauer.md
+++ b/website/content/datasets/0062_neubauer.md
@@ -1,41 +1,66 @@
 ---
 title: "Neubauer (2024)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0062_neubauer"
+first_author: "Neubauer"
+year: 2024
+paper_doi: "https://doi.org/10.1007/s11618-023-01182-8"
+zenodo_doi: "10.5281/zenodo.17347974"
+license: "CC-BY 4.0"
+n_participants: 321
+n_time_points: 84
+n_days: "14"
+topics: "timescales, COVID, academic achievement, study demands"
+sampling_scheme: "6x/day semi-random schedule"
+participants: "undergraduate students"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17347974">10.5281/zenodo.17347974</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0062_neubauer")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0062_neubauer")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Neubauer
-- **Year:** 2024
-- **Paper DOI:** [https://doi.org/10.1007/s11618-023-01182-8](https://doi.org/10.1007/s11618-023-01182-8)
-- **Topics:** timescales, COVID, academic achievement, study demands
-
-## Data Characteristics
-
-- **Participants:** 321 (undergraduate students)
-- **Time Points:** 84
-- **Days:** 14
-- **Beeps per Day:** 6
-- **Sampling Scheme:** 6x/day semi-random schedule
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Neubauer</li>
+<li><strong>Year:</strong> 2024</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1007/s11618-023-01182-8">https://doi.org/10.1007/s11618-023-01182-8</a></li>
+<li><strong>Topics:</strong> timescales, COVID, academic achievement, study demands</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 321 (undergraduate students)</li>
+<li><strong>Time Points:</strong> 84</li>
+<li><strong>Days:</strong> 14</li>
+<li><strong>Beeps per Day:</strong> 6</li>
+<li><strong>Sampling Scheme:</strong> 6x/day semi-random schedule</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/bhq3p](https://osf.io/bhq3p)
-- **Link to Codebook:** [https://osf.io/csfwg](https://osf.io/csfwg)
-- **Link to Code:** [https://osf.io/84kdr/files](https://osf.io/84kdr/files)
 - **License:** CC-BY 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17347974](https://doi.org/10.5281/zenodo.17347974)
-- **R:** `openesm::get_dataset("0062_neubauer")`
-- **Python:** `openesm.get_dataset("0062_neubauer")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17347974">10.5281/zenodo.17347974</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/bhq3p">https://osf.io/bhq3p</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/csfwg">https://osf.io/csfwg</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/84kdr/files">https://osf.io/84kdr/files</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0063_vanwoerkom.md
+++ b/website/content/datasets/0063_vanwoerkom.md
@@ -1,41 +1,66 @@
 ---
 title: "van Woerkom (2022)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0063_vanwoerkom"
+first_author: "van Woerkom"
+year: 2022
+paper_doi: "https://doi.org/10.1007/s10902-022-00546-x"
+zenodo_doi: "10.5281/zenodo.17361708"
+license: "CC BY-NC 4.0"
+n_participants: 173
+n_time_points: 50
+n_days: "5"
+topics: "happiness, well-being, affect, need for autonomy"
+sampling_scheme: "10x/day in 90-minute blocks with 30 to 150 minutes in between"
+participants: "Dutch working adults"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17361708">10.5281/zenodo.17361708</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0063_vanwoerkom")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0063_vanwoerkom")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** van Woerkom
-- **Year:** 2022
-- **Paper DOI:** [https://doi.org/10.1007/s10902-022-00546-x](https://doi.org/10.1007/s10902-022-00546-x)
-- **Topics:** happiness, well-being, affect, need for autonomy
-
-## Data Characteristics
-
-- **Participants:** 173 (Dutch working adults)
-- **Time Points:** 50
-- **Days:** 5
-- **Beeps per Day:** 10
-- **Sampling Scheme:** 10x/day in 90-minute blocks with 30 to 150 minutes in between
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** no
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> van Woerkom</li>
+<li><strong>Year:</strong> 2022</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1007/s10902-022-00546-x">https://doi.org/10.1007/s10902-022-00546-x</a></li>
+<li><strong>Topics:</strong> happiness, well-being, affect, need for autonomy</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 173 (Dutch working adults)</li>
+<li><strong>Time Points:</strong> 50</li>
+<li><strong>Days:</strong> 5</li>
+<li><strong>Beeps per Day:</strong> 10</li>
+<li><strong>Sampling Scheme:</strong> 10x/day in 90-minute blocks with 30 to 150 minutes in between</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> no</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/k98pt/](https://osf.io/k98pt/)
-- **Link to Codebook:** not available
-- **Link to Code:** [https://osf.io/k98pt/files/](https://osf.io/k98pt/files/)
 - **License:** CC BY-NC 4.0
 
-## Data Access
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17361708">10.5281/zenodo.17361708</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/k98pt/">https://osf.io/k98pt/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
 
-- **Zenodo DOI:** [10.5281/zenodo.17361708](https://doi.org/10.5281/zenodo.17361708)
-- **R:** `openesm::get_dataset("0063_vanwoerkom")`
-- **Python:** `openesm.get_dataset("0063_vanwoerkom")`
+<p><strong>Code:</strong> <a href="https://osf.io/k98pt/files/">https://osf.io/k98pt/files/</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0064_wright.md
+++ b/website/content/datasets/0064_wright.md
@@ -1,43 +1,70 @@
 ---
 title: "Wright (2017)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0064_wright"
+first_author: "Wright"
+year: 2017
+paper_doi: "https://doi.org/10.1037/abn0000286"
+zenodo_doi: "10.5281/zenodo.17348495"
+license: "CC BY-NC 4.0"
+n_participants: 222
+n_time_points: 344
+n_days: "21"
+topics: "affect, interpersonal disorders, personality pathology, emotions, social interactions"
+sampling_scheme: "event-contingent based on social interactions"
+participants: "outpatients screened for personality
+pathology and their romantic
+partners"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17348495">10.5281/zenodo.17348495</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0064_wright")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0064_wright")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Wright
-- **Year:** 2017
-- **Paper DOI:** [https://doi.org/10.1037/abn0000286](https://doi.org/10.1037/abn0000286)
-- **Topics:** affect, interpersonal disorders, personality pathology, emotions, social interactions
-
-## Data Characteristics
-
-- **Participants:** 222 (outpatients screened for personality
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Wright</li>
+<li><strong>Year:</strong> 2017</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1037/abn0000286">https://doi.org/10.1037/abn0000286</a></li>
+<li><strong>Topics:</strong> affect, interpersonal disorders, personality pathology, emotions, social interactions</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 222 (outpatients screened for personality
 pathology and their romantic
-partners)
-- **Time Points:** 344
-- **Days:** 21
-- **Beeps per Day:** event-contingent
-- **Sampling Scheme:** event-contingent based on social interactions
-- **Raw Timestamp:** no
-- **Implicit Missingness:** unclear
+partners)</li>
+<li><strong>Time Points:</strong> 344</li>
+<li><strong>Days:</strong> 21</li>
+<li><strong>Beeps per Day:</strong> event-contingent</li>
+<li><strong>Sampling Scheme:</strong> event-contingent based on social interactions</li>
+<li><strong>Raw Timestamp:</strong> no</li>
+<li><strong>Implicit Missingness:</strong> unclear</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/6ghcx/](https://osf.io/6ghcx/)
-- **Link to Codebook:** [-](-)
-- **Link to Code:** [https://osf.io/6ghcx](https://osf.io/6ghcx)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17348495](https://doi.org/10.5281/zenodo.17348495)
-- **R:** `openesm::get_dataset("0064_wright")`
-- **Python:** `openesm.get_dataset("0064_wright")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17348495">10.5281/zenodo.17348495</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/6ghcx/">https://osf.io/6ghcx/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="-">-</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/6ghcx">https://osf.io/6ghcx</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0066_hensel.md
+++ b/website/content/datasets/0066_hensel.md
@@ -1,41 +1,66 @@
 ---
 title: "Hensel (2023)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0066_hensel"
+first_author: "Hensel"
+year: 2023
+paper_doi: "https://doi.org/10.1371/journal.pone.0292735"
+zenodo_doi: "10.5281/zenodo.17348001"
+license: "CC BY-NC 4.0"
+n_participants: 91
+n_time_points: 30
+n_days: "30"
+topics: "spina bifida, incontinence, affect, activities"
+sampling_scheme: "1x/day for a window of four hours"
+participants: "adults with spina bifida and current symptoms of incontinence"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17348001">10.5281/zenodo.17348001</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0066_hensel")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0066_hensel")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Hensel
-- **Year:** 2023
-- **Paper DOI:** [https://doi.org/10.1371/journal.pone.0292735](https://doi.org/10.1371/journal.pone.0292735)
-- **Topics:** spina bifida, incontinence, affect, activities
-
-## Data Characteristics
-
-- **Participants:** 91 (adults with spina bifida and current symptoms of incontinence)
-- **Time Points:** 30
-- **Days:** 30
-- **Beeps per Day:** 1
-- **Sampling Scheme:** 1x/day for a window of four hours
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** unclear
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Hensel</li>
+<li><strong>Year:</strong> 2023</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1371/journal.pone.0292735">https://doi.org/10.1371/journal.pone.0292735</a></li>
+<li><strong>Topics:</strong> spina bifida, incontinence, affect, activities</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 91 (adults with spina bifida and current symptoms of incontinence)</li>
+<li><strong>Time Points:</strong> 30</li>
+<li><strong>Days:</strong> 30</li>
+<li><strong>Beeps per Day:</strong> 1</li>
+<li><strong>Sampling Scheme:</strong> 1x/day for a window of four hours</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> unclear</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/gefqx/files/](https://osf.io/gefqx/files/)
-- **Link to Codebook:** [https://osf.io/gefqx/files/](https://osf.io/gefqx/files/)
-- **Link to Code:** [-](-)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17348001](https://doi.org/10.5281/zenodo.17348001)
-- **R:** `openesm::get_dataset("0066_hensel")`
-- **Python:** `openesm.get_dataset("0066_hensel")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17348001">10.5281/zenodo.17348001</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/gefqx/files/">https://osf.io/gefqx/files/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/gefqx/files/">https://osf.io/gefqx/files/</a></p>
+<p><strong>Code:</strong> <a href="-">-</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0070_vanhalem.md
+++ b/website/content/datasets/0070_vanhalem.md
@@ -1,41 +1,66 @@
 ---
 title: "van Halem (2020)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0070_vanhalem"
+first_author: "van Halem"
+year: 2020
+paper_doi: "https://doi.org/10.1002/per.2252"
+zenodo_doi: "10.5281/zenodo.17348032"
+license: "CC BY-NC 4.0"
+n_participants: 82
+n_time_points: 69
+n_days: "5"
+topics: "skin conductance, affect, arousal, situation"
+sampling_scheme: "random triggers and triggers based on skin conductance"
+participants: "first-year psychology students in Tilburg"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17348032">10.5281/zenodo.17348032</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0070_vanhalem")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0070_vanhalem")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** van Halem
-- **Year:** 2020
-- **Paper DOI:** [https://doi.org/10.1002/per.2252](https://doi.org/10.1002/per.2252)
-- **Topics:** skin conductance, affect, arousal, situation
-
-## Data Characteristics
-
-- **Participants:** 82 (first-year psychology students in Tilburg)
-- **Time Points:** 69
-- **Days:** 5
-- **Beeps per Day:** partially event-contingent
-- **Sampling Scheme:** random triggers and triggers based on skin conductance
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** no
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> van Halem</li>
+<li><strong>Year:</strong> 2020</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1002/per.2252">https://doi.org/10.1002/per.2252</a></li>
+<li><strong>Topics:</strong> skin conductance, affect, arousal, situation</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 82 (first-year psychology students in Tilburg)</li>
+<li><strong>Time Points:</strong> 69</li>
+<li><strong>Days:</strong> 5</li>
+<li><strong>Beeps per Day:</strong> partially event-contingent</li>
+<li><strong>Sampling Scheme:</strong> random triggers and triggers based on skin conductance</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> no</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** yes
-- **Link to Original Data:** [https://osf.io/v4qh9/](https://osf.io/v4qh9/)
-- **Link to Codebook:** [https://osf.io/v8sa7](https://osf.io/v8sa7)
-- **Link to Code:** [https://osf.io/v4qh9/](https://osf.io/v4qh9/)
 - **License:** CC BY-NC 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17348032](https://doi.org/10.5281/zenodo.17348032)
-- **R:** `openesm::get_dataset("0070_vanhalem")`
-- **Python:** `openesm.get_dataset("0070_vanhalem")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17348032">10.5281/zenodo.17348032</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/v4qh9/">https://osf.io/v4qh9/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/v8sa7">https://osf.io/v8sa7</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/v4qh9/">https://osf.io/v4qh9/</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0071_scharbert.md
+++ b/website/content/datasets/0071_scharbert.md
@@ -1,41 +1,66 @@
 ---
 title: "Scharbert (2023)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0071_scharbert"
+first_author: "Scharbert"
+year: 2023
+paper_doi: "https://doi.org/10.1038/s41467-024-44693-6"
+zenodo_doi: "10.5281/zenodo.17348583"
+license: "CC-BY 4.0"
+n_participants: 2855
+n_time_points: 140
+n_days: "28"
+topics: "affect, well-being, Covid, prejudice"
+sampling_scheme: "5x/day with 4 randomly-timed surveys between 9am and 6pm and one daily evening survey after 7pm"
+participants: "adults"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17348583">10.5281/zenodo.17348583</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0071_scharbert")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0071_scharbert")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Scharbert
-- **Year:** 2023
-- **Paper DOI:** [https://doi.org/10.1038/s41467-024-44693-6](https://doi.org/10.1038/s41467-024-44693-6)
-- **Topics:** affect, well-being, Covid, prejudice
-
-## Data Characteristics
-
-- **Participants:** 2855 (adults)
-- **Time Points:** 140
-- **Days:** 28
-- **Beeps per Day:** 5
-- **Sampling Scheme:** 5x/day with 4 randomly-timed surveys between 9am and 6pm and one daily evening survey after 7pm
-- **Raw Timestamp:** no
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Scharbert</li>
+<li><strong>Year:</strong> 2023</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1038/s41467-024-44693-6">https://doi.org/10.1038/s41467-024-44693-6</a></li>
+<li><strong>Topics:</strong> affect, well-being, Covid, prejudice</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 2855 (adults)</li>
+<li><strong>Time Points:</strong> 140</li>
+<li><strong>Days:</strong> 28</li>
+<li><strong>Beeps per Day:</strong> 5</li>
+<li><strong>Sampling Scheme:</strong> 5x/day with 4 randomly-timed surveys between 9am and 6pm and one daily evening survey after 7pm</li>
+<li><strong>Raw Timestamp:</strong> no</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/8f3yu](https://osf.io/8f3yu)
-- **Link to Codebook:** [https://osf.io/nfkze](https://osf.io/nfkze)
-- **Link to Code:** [https://osf.io/z9y5b](https://osf.io/z9y5b)
 - **License:** CC-BY 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17348583](https://doi.org/10.5281/zenodo.17348583)
-- **R:** `openesm::get_dataset("0071_scharbert")`
-- **Python:** `openesm.get_dataset("0071_scharbert")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17348583">10.5281/zenodo.17348583</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/8f3yu">https://osf.io/8f3yu</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/nfkze">https://osf.io/nfkze</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/z9y5b">https://osf.io/z9y5b</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/content/datasets/0072_neubauer.md
+++ b/website/content/datasets/0072_neubauer.md
@@ -1,41 +1,66 @@
 ---
 title: "Neubauer (2020)"
-date: 2025-10-27
+date: 2026-03-11
 draft: false
+dataset_id: "0072_neubauer"
+first_author: "Neubauer"
+year: 2020
+paper_doi: "https://doi.org/10.1111/cdev.13515"
+zenodo_doi: "10.5281/zenodo.17361778"
+license: "CC-BY 4.0"
+n_participants: 562
+n_time_points: 21
+n_days: "21"
+topics: "COVID, schooling, adolescents, family"
+sampling_scheme: "1x/day at 7pm completed until 5am"
+participants: "adults living in a household with a schoolchild"
 ---
 
+<div class="dataset-access-box">
+<h2 class="dataset-access-title">Access Harmonized Data</h2>
+<p class="dataset-access-doi"><strong>Zenodo DOI:</strong> <a href="https://doi.org/10.5281/zenodo.17361778">10.5281/zenodo.17361778</a></p>
+<div class="dataset-code-grid">
+<div class="dataset-code-item"><span class="dataset-code-label">R</span> <code>openesm::get_dataset("0072_neubauer")</code></div>
+<div class="dataset-code-item"><span class="dataset-code-label">Python</span> <code>openesm.get_dataset("0072_neubauer")</code></div>
+</div>
+</div>
 
-## Study Information
-
-- **First Author:** Neubauer
-- **Year:** 2020
-- **Paper DOI:** [https://doi.org/10.1111/cdev.13515](https://doi.org/10.1111/cdev.13515)
-- **Topics:** COVID, schooling, adolescents, family
-
-## Data Characteristics
-
-- **Participants:** 562 (adults living in a household with a schoolchild)
-- **Time Points:** 21
-- **Days:** 21
-- **Beeps per Day:** 1
-- **Sampling Scheme:** 1x/day at 7pm completed until 5am
-- **Raw Timestamp:** yes
-- **Implicit Missingness:** yes
+<div class="dataset-meta-grid">
+<div class="dataset-meta-card">
+<h2>Study Information</h2>
+<ul>
+<li><strong>First Author:</strong> Neubauer</li>
+<li><strong>Year:</strong> 2020</li>
+<li><strong>Paper DOI:</strong> <a href="https://doi.org/10.1111/cdev.13515">https://doi.org/10.1111/cdev.13515</a></li>
+<li><strong>Topics:</strong> COVID, schooling, adolescents, family</li>
+</ul>
+</div>
+<div class="dataset-meta-card">
+<h2>Data Characteristics</h2>
+<ul>
+<li><strong>Participants:</strong> 562 (adults living in a household with a schoolchild)</li>
+<li><strong>Time Points:</strong> 21</li>
+<li><strong>Days:</strong> 21</li>
+<li><strong>Beeps per Day:</strong> 1</li>
+<li><strong>Sampling Scheme:</strong> 1x/day at 7pm completed until 5am</li>
+<li><strong>Raw Timestamp:</strong> yes</li>
+<li><strong>Implicit Missingness:</strong> yes</li>
+</ul>
+</div>
+</div>
 
 ## Data Availability
 
 - **Cross-sectional Data:** yes
 - **Passive Sensor Data:** no
-- **Link to Original Data:** [https://osf.io/wcerj/](https://osf.io/wcerj/)
-- **Link to Codebook:** [https://osf.io/tyc32](https://osf.io/tyc32)
-- **Link to Code:** [https://osf.io/et869](https://osf.io/et869)
 - **License:** CC-BY 4.0
 
-## Data Access
-
-- **Zenodo DOI:** [10.5281/zenodo.17361778](https://doi.org/10.5281/zenodo.17361778)
-- **R:** `openesm::get_dataset("0072_neubauer")`
-- **Python:** `openesm.get_dataset("0072_neubauer")`
+<div class="dataset-links">
+<p><strong>Harmonized Data (Zenodo):</strong> <a href="https://doi.org/10.5281/zenodo.17361778">10.5281/zenodo.17361778</a></p>
+<p><strong>Original Source Data:</strong> <a href="https://osf.io/wcerj/">https://osf.io/wcerj/</a> <span class="dataset-link-note">(not harmonized — for reference only)</span></p>
+<p><strong>Codebook:</strong> <a href="https://osf.io/tyc32">https://osf.io/tyc32</a></p>
+<p><strong>Code:</strong> <a href="https://osf.io/et869">https://osf.io/et869</a></p>
+</div>
 
 ## Additional Comments
 

--- a/website/layouts/partials/extend_head.html
+++ b/website/layouts/partials/extend_head.html
@@ -1,9 +1,9 @@
 {{- /* Dataset JSON-LD (Schema.org) — only on individual dataset pages */ -}}
 {{- if .Params.dataset_id -}}
 
-{{- /* Map license strings to canonical CC URLs */ -}}
+{{- /* Map license strings to canonical URLs (CC and common SPDX identifiers) */ -}}
 {{- $licenseUrl := "" -}}
-{{- $license := .Params.license | lower -}}
+{{- $license := .Params.license | default "" | lower -}}
 {{- if or (eq $license "cc-by 4.0") (eq $license "cc by 4.0") (eq $license "cc-by-4.0") -}}
   {{- $licenseUrl = "https://creativecommons.org/licenses/by/4.0/" -}}
 {{- else if or (eq $license "cc-by-nc 4.0") (eq $license "cc by-nc 4.0") (eq $license "cc-by-nc-4.0") -}}
@@ -14,8 +14,12 @@
   {{- $licenseUrl = "https://creativecommons.org/licenses/by-nc-sa/4.0/" -}}
 {{- else if or (eq $license "cc0") (eq $license "cc0 1.0") (eq $license "cc0-1.0") -}}
   {{- $licenseUrl = "https://creativecommons.org/publicdomain/zero/1.0/" -}}
-{{- else -}}
-  {{- $licenseUrl = .Params.license -}}
+{{- else if or (eq $license "gpl-3.0") (eq $license "gpl-3.0-only") (eq $license "gpl-3.0-or-later") -}}
+  {{- $licenseUrl = "https://spdx.org/licenses/GPL-3.0.html" -}}
+{{- else if or (eq $license "mit") (eq $license "mit license") -}}
+  {{- $licenseUrl = "https://spdx.org/licenses/MIT.html" -}}
+{{- else if or (eq $license "apache-2.0") (eq $license "apache 2.0") -}}
+  {{- $licenseUrl = "https://spdx.org/licenses/Apache-2.0.html" -}}
 {{- end -}}
 
 {{- $description := printf "%s — ESM dataset by %s (%d). Part of the openESM database of open experience sampling datasets." (.Params.topics | default "Experience sampling dataset") .Params.first_author (.Params.year | int) -}}

--- a/website/layouts/partials/extend_head.html
+++ b/website/layouts/partials/extend_head.html
@@ -1,0 +1,71 @@
+{{- /* Dataset JSON-LD (Schema.org) — only on individual dataset pages */ -}}
+{{- if .Params.dataset_id -}}
+
+{{- /* Map license strings to canonical CC URLs */ -}}
+{{- $licenseUrl := "" -}}
+{{- $license := .Params.license | lower -}}
+{{- if or (eq $license "cc-by 4.0") (eq $license "cc by 4.0") (eq $license "cc-by-4.0") -}}
+  {{- $licenseUrl = "https://creativecommons.org/licenses/by/4.0/" -}}
+{{- else if or (eq $license "cc-by-nc 4.0") (eq $license "cc by-nc 4.0") (eq $license "cc-by-nc-4.0") -}}
+  {{- $licenseUrl = "https://creativecommons.org/licenses/by-nc/4.0/" -}}
+{{- else if or (eq $license "cc-by-sa 4.0") (eq $license "cc by-sa 4.0") (eq $license "cc-by-sa-4.0") -}}
+  {{- $licenseUrl = "https://creativecommons.org/licenses/by-sa/4.0/" -}}
+{{- else if or (eq $license "cc-by-nc-sa 4.0") (eq $license "cc by-nc-sa 4.0") (eq $license "cc-by-nc-sa-4.0") -}}
+  {{- $licenseUrl = "https://creativecommons.org/licenses/by-nc-sa/4.0/" -}}
+{{- else if or (eq $license "cc0") (eq $license "cc0 1.0") (eq $license "cc0-1.0") -}}
+  {{- $licenseUrl = "https://creativecommons.org/publicdomain/zero/1.0/" -}}
+{{- else -}}
+  {{- $licenseUrl = .Params.license -}}
+{{- end -}}
+
+{{- $description := printf "%s — ESM dataset by %s (%d). Part of the openESM database of open experience sampling datasets." (.Params.topics | default "Experience sampling dataset") .Params.first_author (.Params.year | int) -}}
+{{- $sizeStr := printf "%d participants, %d time points" (.Params.n_participants | int) (.Params.n_time_points | int) -}}
+{{- $zenodoDOI := .Params.zenodo_doi | default "" -}}
+{{- $zenodoUrl := "" -}}
+{{- if $zenodoDOI -}}
+  {{- $zenodoUrl = printf "https://doi.org/%s" $zenodoDOI -}}
+{{- end -}}
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org/",
+  "@type": "Dataset",
+  "name": {{ .Title | jsonify }},
+  "description": {{ $description | jsonify }},
+  "url": {{ .Permalink | jsonify }},
+  {{- if $zenodoDOI }}
+  "identifier": {{ printf "https://doi.org/%s" $zenodoDOI | jsonify }},
+  {{- end }}
+  "creator": {
+    "@type": "Person",
+    "name": {{ .Params.first_author | jsonify }}
+  },
+  {{- if .Params.year }}
+  "datePublished": {{ .Params.year | string | jsonify }},
+  {{- end }}
+  {{- if $licenseUrl }}
+  "license": {{ $licenseUrl | jsonify }},
+  {{- end }}
+  {{- if .Params.sampling_scheme }}
+  "measurementTechnique": {{ .Params.sampling_scheme | jsonify }},
+  {{- end }}
+  "size": {{ $sizeStr | jsonify }},
+  "keywords": {{ .Params.topics | jsonify }},
+  "inLanguage": "en",
+  "includedInDataCatalog": {
+    "@type": "DataCatalog",
+    "name": "openESM",
+    "url": {{ site.Home.Permalink | jsonify }}
+  }{{- if $zenodoUrl }},
+  "distribution": [
+    {
+      "@type": "DataDownload",
+      "contentUrl": {{ $zenodoUrl | jsonify }},
+      "encodingFormat": "text/tab-separated-values",
+      "description": "Harmonized dataset provided via openESM"
+    }
+  ]
+  {{- end }}
+}
+</script>
+{{- end -}}


### PR DESCRIPTION
- Add Schema.org Dataset JSON-LD to all dataset pages via a new extend_head.html partial (PaperMod's built-in override hook). Structured data includes name, description, creator, license, distribution (Zenodo), measurementTechnique, and includedInDataCatalog, making datasets discoverable via Google Dataset Search.

- Extend generate_dataset_pages.js to embed structured frontmatter params (dataset_id, first_author, year, paper_doi, zenodo_doi, license, n_participants, n_time_points, n_days, topics, sampling_scheme, participants) used by the Hugo template for JSON-LD generation.

- Restructure individual dataset page layout: add a prominent "Access Harmonized Data" callout box at the top with the Zenodo DOI and R/Python code snippets; use a two-column grid for Study Information and Data Characteristics; relabel OSF link as "Original Source Data (not harmonized — for reference only)" to clarify that Zenodo is the canonical source.

- Add supporting CSS classes (dataset-access-box, dataset-meta-grid, dataset-meta-card, dataset-links, dataset-link-note, dataset-code-grid) to custom.css.

- Regenerate all 62 dataset pages with the new template.